### PR TITLE
HU14 - Registro de Nuevo Contrato y Reglas de Tarifa

### DIFF
--- a/apps/mfe-contratos/__tests__/unit/hu14-registro-contrato/RegistroContratoPage.test.tsx
+++ b/apps/mfe-contratos/__tests__/unit/hu14-registro-contrato/RegistroContratoPage.test.tsx
@@ -1,13 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import RegistroContratoPage from '../../../src/modules/registro-contrato/pages/RegistroContratoPage';
-import { crearContrato } from '@nanutech/api-client';
-
-vi.mock('@nanutech/api-client', () => ({
-  crearContrato: vi.fn(),
-}));
-
-const crearContratoMock = vi.mocked(crearContrato);
 
 const completarPasoInformacionGeneral = () => {
   fireEvent.change(screen.getByLabelText(/Nombre del Cliente/i), {
@@ -22,22 +15,19 @@ const completarPasoInformacionGeneral = () => {
   fireEvent.change(screen.getByLabelText(/Fecha de Inicio/i), {
     target: { value: '2026-06-01' },
   });
-  fireEvent.change(screen.getByLabelText(/Fecha de Fin/i), {
+  fireEvent.change(screen.getByLabelText(/Fecha de Vencimiento/i), {
     target: { value: '2026-12-31' },
-  });
-  fireEvent.change(screen.getByLabelText(/Descripcion del Servicio|Descripción del Servicio/i), {
-    target: { value: 'Servicio de transporte Lima - Callao' },
   });
 };
 
 const completarPasoRuta = () => {
-  fireEvent.change(screen.getByPlaceholderText(/Av\. Lima 123/i), {
-    target: { value: 'Av. Lima 123' },
+  fireEvent.change(screen.getByLabelText(/Punto de Partida/i), {
+    target: { value: 'Lima - Terminal Ate' },
   });
-  fireEvent.change(screen.getByPlaceholderText(/Calle Arequipa 456/i), {
-    target: { value: 'Puerto del Callao' },
+  fireEvent.change(screen.getByLabelText(/Punto de Llegada/i), {
+    target: { value: 'Lima - Terminal Callao' },
   });
-  fireEvent.change(screen.getByPlaceholderText(/25\.50/i), {
+  fireEvent.change(screen.getByLabelText(/Distancia Estimada/i), {
     target: { value: '25.5' },
   });
 };
@@ -62,25 +52,15 @@ const avanzarAlPasoTarifas = () => {
   fireEvent.click(screen.getByRole('button', { name: /Siguiente/i }));
 };
 
-describe('RegistroContratoPage - HU14', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
+describe('RegistroContratoPage - HU14 mock-first', () => {
   it('renderiza el primer paso del registro de contrato', () => {
     render(<RegistroContratoPage onBack={vi.fn()} />);
 
-    expect(screen.getByRole('heading', { name: /Registro de Contrato/i })).toBeTruthy();
-    expect(screen.getByText(/Paso 1 de 3/i)).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Registrar Nuevo Contrato/i })).toBeTruthy();
+    expect(screen.getByText(/Paso 1/i)).toBeTruthy();
     expect(screen.getByLabelText(/Nombre del Cliente/i)).toBeTruthy();
     expect(screen.getByLabelText(/RUC/i)).toBeTruthy();
-    expect(screen.getByRole<HTMLButtonElement>('button', { name: /Anterior/i }).disabled).toBe(
-      true
-    );
+    expect(screen.getByRole('button', { name: /Cancelar/i })).toBeTruthy();
   });
 
   it('muestra errores de validacion cuando intenta avanzar sin datos validos', () => {
@@ -99,7 +79,7 @@ describe('RegistroContratoPage - HU14', () => {
     fireEvent.click(screen.getByRole('button', { name: /Siguiente/i }));
     fireEvent.click(screen.getByRole('button', { name: /Siguiente/i }));
 
-    expect(screen.getByText(/Paso 2 de 3/i)).toBeTruthy();
+    expect(screen.getByText(/Paso 2/i)).toBeTruthy();
     expect(screen.getAllByText(/Campo obligatorio/i)).toHaveLength(2);
     expect(screen.getByText(/distancia debe ser mayor a 0/i)).toBeTruthy();
   });
@@ -110,32 +90,16 @@ describe('RegistroContratoPage - HU14', () => {
     avanzarAlPasoTarifas();
     completarPasoTarifas();
 
-    expect(screen.getByText(/Paso 3 de 3/i)).toBeTruthy();
-    expect(screen.getByText(/Tarifa Total: S\/ 81.60/i)).toBeTruthy();
+    expect(screen.getByText(/Paso 3/i)).toBeTruthy();
+    expect(screen.getByText(/Tarifa Total inicial/i)).toBeTruthy();
+    expect(screen.getByText('S/ 81.60')).toBeTruthy();
     expect(screen.getByText('Empresa Constructora ABC S.A.C.')).toBeTruthy();
     expect(screen.getByText('20123456789')).toBeTruthy();
   });
 
-  it('envia el contrato al api y vuelve al listado cuando el registro es exitoso', async () => {
+  it('crea un contrato mock y muestra el estado final exitoso', async () => {
     const onBack = vi.fn();
     const onRegistered = vi.fn();
-    crearContratoMock.mockResolvedValue({
-      id: 'CON-001',
-      codigo: 'CONT-2026-001',
-      cliente: 'Empresa Constructora ABC S.A.C.',
-      ruc: '20123456789',
-      tipo_servicio: 'POR_KM',
-      fecha_inicio: '2026-06-01',
-      fecha_fin: '2026-12-31',
-      origen: 'Av. Lima 123',
-      destino: 'Puerto del Callao',
-      distancia_estimada_km: 25.5,
-      tarifa_por_km: 3.2,
-      tarifa_por_hora: 50,
-      tarifa_espera: 12.5,
-      moneda: 'PEN',
-      tarifa: 81.6,
-    });
 
     render(<RegistroContratoPage onBack={onBack} onRegistered={onRegistered} />);
 
@@ -144,57 +108,27 @@ describe('RegistroContratoPage - HU14', () => {
     fireEvent.click(screen.getByRole('button', { name: /Registrar Contrato/i }));
 
     await waitFor(() => {
-      expect(crearContratoMock).toHaveBeenCalledWith({
-        cliente: 'Empresa Constructora ABC S.A.C.',
-        ruc: '20123456789',
-        descripcion: 'Servicio de transporte Lima - Callao',
-        tipo_servicio: 'POR_KM',
-        fecha_inicio: '2026-06-01',
-        fecha_fin: '2026-12-31',
-        origen: 'Av. Lima 123',
-        destino: 'Puerto del Callao',
-        distancia_estimada_km: 25.5,
-        tarifa_por_km: 3.2,
-        tarifa_por_hora: 50,
-        tarifa_espera: 12.5,
-        moneda: 'PEN',
-      });
+      expect(onRegistered).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cliente: 'Empresa Constructora ABC S.A.C.',
+          codigo: expect.stringMatching(/^CTR-2026-/),
+          tarifa: 81.6,
+        })
+      );
     });
-    expect(onRegistered).toHaveBeenCalledWith(
-      expect.objectContaining({ codigo: 'CONT-2026-001', tarifa: 81.6 })
-    );
-    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/Contrato registrado exitosamente/i)).toBeTruthy();
+    expect(onBack).not.toHaveBeenCalled();
   });
 
   it('no registra si falta completar las tarifas obligatorias', () => {
-    render(<RegistroContratoPage onBack={vi.fn()} />);
+    const onRegistered = vi.fn();
+    render(<RegistroContratoPage onBack={vi.fn()} onRegistered={onRegistered} />);
 
     avanzarAlPasoTarifas();
     fireEvent.click(screen.getByRole('button', { name: /Registrar Contrato/i }));
 
-    expect(crearContratoMock).not.toHaveBeenCalled();
+    expect(onRegistered).not.toHaveBeenCalled();
     expect(screen.getByText(/Debe ser mayor a 0/i)).toBeTruthy();
     expect(screen.getAllByText(/Campo obligatorio/i)).toHaveLength(2);
-  });
-
-  it('muestra el mensaje de error del api cuando falla el registro', async () => {
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
-    crearContratoMock.mockRejectedValue({
-      response: {
-        data: {
-          message: 'El RUC ya tiene un contrato vigente',
-        },
-      },
-    });
-
-    render(<RegistroContratoPage onBack={vi.fn()} />);
-
-    avanzarAlPasoTarifas();
-    completarPasoTarifas();
-    fireEvent.click(screen.getByRole('button', { name: /Registrar Contrato/i }));
-
-    await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith('El RUC ya tiene un contrato vigente');
-    });
   });
 });

--- a/apps/mfe-contratos/src/modules/registro-contrato/components/RegistroFormControls.tsx
+++ b/apps/mfe-contratos/src/modules/registro-contrato/components/RegistroFormControls.tsx
@@ -1,0 +1,261 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Componentes pequenos y reutilizables del formulario de registro.
+ *
+ * Este archivo evita que RegistroContratoPage tenga detalles repetidos de inputs,
+ * errores, labels y resumenes. No contiene reglas de negocio: solo presentacion.
+ */
+
+// Caja informativa usada para explicar secciones del wizard.
+export function Callout({
+  title,
+  children,
+  tone,
+}: {
+  title: string;
+  children: string;
+  tone: 'blue' | 'amber';
+}) {
+  const styles =
+    tone === 'blue'
+      ? 'border-blue-200 bg-blue-50 text-blue-900'
+      : 'border-amber-200 bg-amber-50 text-amber-900';
+
+  return (
+    <div className={`rounded-lg border p-5 ${styles}`}>
+      <h3 className="font-bold">{title}</h3>
+      <p className="mt-2 text-sm">{children}</p>
+    </div>
+  );
+}
+
+// Tarjeta principal de cada paso, con titulo, subtitulo e icono textual.
+export function StepCard({
+  title,
+  subtitle,
+  icon,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  icon: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+      <header className="flex items-center gap-3 border-b border-slate-100 px-5 py-4">
+        <div className="grid h-9 w-9 place-items-center rounded-lg bg-blue-50 text-sm font-bold text-blue-700">
+          {icon}
+        </div>
+        <div>
+          <h2 className="font-bold text-slate-950">{title}</h2>
+          <p className="text-xs text-slate-500">{subtitle}</p>
+        </div>
+      </header>
+      <div className="p-5 sm:p-6">{children}</div>
+    </section>
+  );
+}
+
+// Separador con titulo azul usado para dividir bloques dentro de una tarjeta.
+export function SectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-3 py-2 text-[11px] font-bold uppercase text-blue-600">
+      <span className="h-px flex-1 bg-blue-100" />
+      <span>{children}</span>
+      <span className="h-px flex-1 bg-blue-100" />
+    </div>
+  );
+}
+
+// Label comun para inputs. Agrega asterisco cuando el campo es obligatorio.
+export function Label({ text, required }: { text: string; required?: boolean }) {
+  return (
+    <span className="mb-1.5 block text-sm font-bold">
+      {text}
+      {required && <span className="text-red-500">*</span>}
+    </span>
+  );
+}
+
+// Input base para texto, fecha o numero, con soporte para helper, error y estado OK.
+export function InputField(props: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+  type?: string;
+  placeholder?: string;
+  helper?: string;
+  maxLength?: number;
+  required?: boolean;
+  success?: boolean;
+}) {
+  return (
+    <label>
+      <Label text={props.label} required={props.required} />
+      <input
+        type={props.type || 'text'}
+        value={props.value}
+        placeholder={props.placeholder}
+        maxLength={props.maxLength}
+        onChange={(event) => props.onChange(event.target.value)}
+        className={`field-base ${
+          props.error
+            ? 'border-red-500 focus:ring-red-100'
+            : props.success
+              ? 'border-emerald-500 focus:ring-emerald-100'
+              : 'border-transparent focus:ring-blue-100'
+        }`}
+      />
+      {props.helper && !props.error && (
+        <p className={`mt-1.5 text-xs ${props.success ? 'text-emerald-700' : 'text-slate-500'}`}>
+          {props.success ? 'OK ' : ''}
+          {props.helper}
+        </p>
+      )}
+      {props.error && <ErrorMessage text={props.error} />}
+    </label>
+  );
+}
+
+// Select base para catalogos del formulario, como tipo de servicio y terminales.
+export function SelectField(props: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: Array<{ value: string; label: string }>;
+  error?: string;
+  required?: boolean;
+}) {
+  return (
+    <label>
+      <Label text={props.label} required={props.required} />
+      <select
+        value={props.value}
+        onChange={(event) => props.onChange(event.target.value)}
+        className={`field-base ${props.error ? 'border-red-500 focus:ring-red-100' : 'border-transparent focus:ring-blue-100'}`}
+      >
+        {props.options.map((option) => (
+          <option key={option.label} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {props.error && <ErrorMessage text={props.error} />}
+    </label>
+  );
+}
+
+// Input monetario con prefijo S/. Mantiene el valor como string para inputs controlados.
+export function MoneyInput(props: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+  helper?: string;
+}) {
+  return (
+    <label>
+      <Label text={props.label} required />
+      <div
+        className={`flex overflow-hidden rounded-lg border bg-slate-100 focus-within:bg-white focus-within:ring-2 ${
+          props.error
+            ? 'border-red-500 focus-within:ring-red-100'
+            : 'border-transparent focus-within:ring-blue-100'
+        }`}
+      >
+        <span className="px-4 py-3 font-semibold text-slate-600">S/</span>
+        <input
+          type="number"
+          step="0.01"
+          min="0"
+          value={props.value}
+          placeholder="0.00"
+          onChange={(event) => props.onChange(event.target.value)}
+          className="w-full border-0 bg-transparent px-2 py-3 outline-none"
+        />
+      </div>
+      {props.helper && !props.error && <p className="mt-1.5 text-xs text-slate-500">{props.helper}</p>}
+      {props.error && <ErrorMessage text={props.error} />}
+    </label>
+  );
+}
+
+// Franja informativa compacta, similar a las notas azules de la referencia visual.
+export function InlineNotice({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-xs font-medium text-blue-800">
+      {children}
+    </div>
+  );
+}
+
+// Mensaje de error estandarizado para todos los controles.
+export function ErrorMessage({ text }: { text: string }) {
+  return <p className="mt-1.5 text-sm font-medium text-red-600">! {text}</p>;
+}
+
+// Par label/valor usado en el resumen final del contrato.
+export function Summary({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <div>
+      <p className="text-sm text-slate-500">{label}</p>
+      <p className={highlight ? 'text-2xl font-bold text-blue-700' : 'font-bold'}>
+        {value || '-'}
+      </p>
+    </div>
+  );
+}
+
+// Resumen lateral del paso de tarifas, orientado a validar datos antes de registrar.
+export function ContractSummaryPanel({
+  cliente,
+  ruc,
+  tipo,
+  inicio,
+  fin,
+  origen,
+  destino,
+  distancia,
+  tarifaKm,
+  tarifaHora,
+  tarifaEspera,
+}: {
+  cliente: string;
+  ruc: string;
+  tipo: string;
+  inicio: string;
+  fin: string;
+  origen: string;
+  destino: string;
+  distancia: string;
+  tarifaKm: string;
+  tarifaHora: string;
+  tarifaEspera: string;
+}) {
+  return (
+    <aside className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-xs text-slate-700">
+      <p className="font-bold uppercase text-blue-700">Resumen del contrato</p>
+      <div className="mt-4 space-y-3">
+        <Summary label="Cliente" value={cliente} />
+        <Summary label="RUC" value={ruc} />
+        <Summary label="Tipo" value={tipo} />
+        <Summary label="Inicio" value={inicio} />
+        <Summary label="Vence" value={fin} />
+        <Summary label="Partida" value={origen} />
+        <Summary label="Llegada" value={destino} />
+        <Summary label="Distancia" value={distancia ? `${distancia} km` : '-'} />
+        <Summary label="Por km" value={tarifaKm ? `S/ ${Number(tarifaKm).toFixed(2)}` : '-'} />
+        <Summary label="Hora viaje" value={tarifaHora ? `S/ ${Number(tarifaHora).toFixed(2)}` : '-'} />
+        <Summary label="Hora espera" value={tarifaEspera ? `S/ ${Number(tarifaEspera).toFixed(2)}` : '-'} />
+      </div>
+    </aside>
+  );
+}
+
+// Wrapper simple para mantener spacing consistente entre pasos del wizard.
+export function FormSection({ children }: { children: ReactNode }) {
+  return <div className="grid gap-6">{children}</div>;
+}

--- a/apps/mfe-contratos/src/modules/registro-contrato/components/Stepper.tsx
+++ b/apps/mfe-contratos/src/modules/registro-contrato/components/Stepper.tsx
@@ -1,0 +1,62 @@
+import { registroSteps } from '../constants';
+
+/**
+ * Indicador visual del progreso del registro.
+ * Recibe el paso actual y pinta cada etapa como pendiente, activa o completada.
+ */
+export function Stepper({ step }: { step: number }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-5 py-4 shadow-sm">
+      <div className="grid gap-5 sm:grid-cols-3">
+        {registroSteps.map((item, index) => {
+          // Los pasos son 1-based porque asi se muestran al usuario.
+          const number = index + 1;
+          const active = step === number;
+          const done = step > number;
+
+          return (
+            <div key={item.title} className="relative flex items-center gap-3 sm:justify-center">
+              {index < registroSteps.length - 1 && (
+                // Linea de conexion entre pasos, verde cuando la etapa anterior ya termino.
+                <div
+                  className={`absolute left-[64%] top-5 hidden h-px w-[72%] sm:block ${
+                    step > number ? 'bg-emerald-500' : 'bg-blue-200'
+                  }`}
+                />
+              )}
+
+              <div
+                className={`z-10 grid h-10 w-10 place-items-center rounded-full text-sm font-bold ${
+                  done
+                    ? 'bg-emerald-500 text-white'
+                    : active
+                      ? 'bg-blue-600 text-white ring-4 ring-blue-100'
+                      : 'border border-slate-300 bg-white text-slate-500'
+                }`}
+              >
+                {done ? 'OK' : number}
+              </div>
+
+              <div>
+                <p
+                  className={`text-[10px] font-bold uppercase ${
+                    done ? 'text-emerald-700' : active ? 'text-blue-700' : 'text-slate-400'
+                  }`}
+                >
+                  {item.subtitle}
+                </p>
+                <p
+                  className={`text-xs font-bold ${
+                    done ? 'text-emerald-700' : active ? 'text-blue-700' : 'text-slate-600'
+                  }`}
+                >
+                  {item.title}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/mfe-contratos/src/modules/registro-contrato/constants.ts
+++ b/apps/mfe-contratos/src/modules/registro-contrato/constants.ts
@@ -1,0 +1,52 @@
+import type { TipoServicio } from '@nanutech/api-client';
+import { getTodayLocal } from './utils/dateUtils';
+import type { RegistroContratoForm } from './types';
+
+// Etiquetas del wizard. Mantener aqui permite modificar los nombres sin tocar el componente Stepper.
+export const registroSteps = [
+  { title: 'Datos Generales', subtitle: 'Paso 1' },
+  { title: 'Ruta de Servicio', subtitle: 'Paso 2' },
+  { title: 'Reglas de Tarifa', subtitle: 'Paso 3' },
+];
+
+// Opciones permitidas por el dominio de contratos.
+// Deben mantenerse alineadas con TipoServicio del api-client.
+export const tipoServicioOptions: Array<{ value: TipoServicio | ''; label: string }> = [
+  { value: '', label: 'Seleccionar tipo' },
+  { value: 'POR_VIAJE', label: 'Por Viaje' },
+  { value: 'POR_HORA', label: 'Por Hora' },
+  { value: 'POR_TONELADA', label: 'Por Tonelada' },
+  { value: 'POR_KM', label: 'Por Kilometro' },
+  { value: 'MENSUAL', label: 'Mensual' },
+];
+
+// Rutas sugeridas para el demo de la HU. Luego pueden venir de un catalogo real.
+export const terminalOptions = [
+  { value: '', label: 'Seleccionar ciudad/terminal' },
+  { value: 'Lima - Terminal Ate', label: 'Lima - Terminal Ate' },
+  { value: 'Lima - Terminal Callao', label: 'Lima - Terminal Callao' },
+  { value: 'Arequipa - Terminal Central', label: 'Arequipa - Terminal Central' },
+  { value: 'Trujillo - Terminal Norte', label: 'Trujillo - Terminal Norte' },
+  { value: 'Cusco - Terminal Sur', label: 'Cusco - Terminal Sur' },
+  { value: 'Piura - Terminal Oeste', label: 'Piura - Terminal Oeste' },
+];
+
+// Estado inicial de un registro nuevo.
+// Las fechas se generan en local para evitar desfases por UTC en input type="date".
+export const initialRegistroContratoForm: RegistroContratoForm = {
+  cliente: '',
+  ruc: '',
+  tipo_servicio: '',
+  fecha_inicio: getTodayLocal(),
+  fecha_fin: '',
+  descripcion: '',
+  origen: '',
+  destino: '',
+  distancia_estimada_km: '',
+  tiempo_estimado_horas: '',
+  observaciones_ruta: '',
+  tarifa_por_km: '',
+  tarifa_por_hora: '',
+  tarifa_por_tonelada: '',
+  tarifa_espera: '',
+};

--- a/apps/mfe-contratos/src/modules/registro-contrato/index.ts
+++ b/apps/mfe-contratos/src/modules/registro-contrato/index.ts
@@ -1,0 +1,2 @@
+// Punto publico reservado para exports del modulo registro-contrato.
+// Puede usarse luego para exponer RegistroContratoPage sin revelar su carpeta pages.

--- a/apps/mfe-contratos/src/modules/registro-contrato/mocks/registroContratoRepository.ts
+++ b/apps/mfe-contratos/src/modules/registro-contrato/mocks/registroContratoRepository.ts
@@ -1,0 +1,29 @@
+import type { Contrato } from '@nanutech/api-client';
+import { buildCrearContratoPayload, getRegistroTarifaTotal } from '../utils/registroContratoMapper';
+import type { RegistroContratoForm } from '../types';
+
+/**
+ * Repositorio mock de registro.
+ *
+ * Este archivo simula la respuesta de POST /contratos. Cuando el backend este listo,
+ * se puede reemplazar esta funcion por una llamada a crearContrato(...) del api-client
+ * manteniendo la misma firma Promise<Contrato>.
+ */
+export const createMockContrato = async (form: RegistroContratoForm): Promise<Contrato> => {
+  // Reutiliza el mapper para que el mock tenga el mismo payload que el API real.
+  const payload = buildCrearContratoPayload(form);
+  const timestamp = Date.now();
+  const uniqueSuffix = timestamp.toString(36).toUpperCase();
+
+  // Contrato enriquecido con campos que normalmente devolveria el backend.
+  return {
+    id: `mock-${uniqueSuffix}`,
+    codigo: `CTR-2026-${uniqueSuffix}`,
+    ...payload,
+    tarifa: getRegistroTarifaTotal(form),
+    estado: 'VIGENTE',
+    activo: true,
+    camiones_asignados: 0,
+    proximo_a_vencer: false,
+  };
+};

--- a/apps/mfe-contratos/src/modules/registro-contrato/pages/RegistroContratoPage.tsx
+++ b/apps/mfe-contratos/src/modules/registro-contrato/pages/RegistroContratoPage.tsx
@@ -1,585 +1,441 @@
 import { useMemo, useState } from 'react';
-import { crearContrato, type Contrato, type TipoServicio } from '@nanutech/api-client';
+import {
+  ContractSummaryPanel,
+  ErrorMessage,
+  InlineNotice,
+  InputField,
+  Label,
+  MoneyInput,
+  SectionTitle,
+  SelectField,
+  StepCard,
+} from '../components/RegistroFormControls';
+import { Stepper } from '../components/Stepper';
+import { initialRegistroContratoForm, terminalOptions, tipoServicioOptions } from '../constants';
+import { createMockContrato } from '../mocks/registroContratoRepository';
+import type {
+  RegistroContratoErrors,
+  RegistroContratoForm,
+  RegistroContratoPageProps,
+  RegistroContratoSuccess,
+} from '../types';
+import { getRegistroTarifaTotal } from '../utils/registroContratoMapper';
+import {
+  hasErrors,
+  validateGeneralStep,
+  validateRatesStep,
+  validateRouteStep,
+} from '../utils/registroContratoValidators';
 
-type Props = {
-  onBack: () => void;
-  onRegistered?: (contrato: Contrato) => void;
-};
-
-type Form = {
-  cliente: string;
-  ruc: string;
-  tipo_servicio: TipoServicio | '';
-  fecha_inicio: string;
-  fecha_fin: string;
-  descripcion: string;
-  origen: string;
-  destino: string;
-  distancia_estimada_km: string;
-  tarifa_por_km: string;
-  tarifa_por_hora: string;
-  tarifa_espera: string;
-};
-
-const getTodayLocal = () => {
-  const date = new Date();
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-
-  return `${year}-${month}-${day}`;
-};
-
-const initialForm: Form = {
-  cliente: '',
-  ruc: '',
-  tipo_servicio: 'POR_VIAJE',
-  fecha_inicio: getTodayLocal(),
-  fecha_fin: '',
-  descripcion: '',
-  origen: '',
-  destino: '',
-  distancia_estimada_km: '',
-  tarifa_por_km: '',
-  tarifa_por_hora: '',
-  tarifa_espera: '',
-};
-
-export default function RegistroContratoPage({ onBack, onRegistered }: Props) {
+/**
+ * HU Registro de Contrato Comercial.
+ *
+ * Esta pagina es el entregable principal de la historia:
+ * 1. Captura datos generales del cliente y vigencia.
+ * 2. Captura parametros de ruta que luego usara monitoreo/GPS.
+ * 3. Captura tarifas, calcula tarifa total y genera un ID unico mock.
+ *
+ * El backend aun no esta listo; por eso la creacion esta aislada en
+ * createMockContrato(). Cuando exista el API AWS, se reemplaza ese repositorio
+ * sin reescribir el flujo visual ni las validaciones.
+ */
+export default function RegistroContratoPage({ onBack, onRegistered }: RegistroContratoPageProps) {
+  // Paso actual del wizard: 1 datos generales, 2 ruta de servicio, 3 reglas de tarifa.
   const [step, setStep] = useState(1);
-  const [form, setForm] = useState<Form>(initialForm);
-  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Estado controlado de todos los campos del formulario.
+  const [form, setForm] = useState<RegistroContratoForm>(initialRegistroContratoForm);
+
+  // Errores por campo, poblados por los validadores del modulo.
+  const [errors, setErrors] = useState<RegistroContratoErrors>({});
+
+  // Estado de guardado para deshabilitar el boton mientras se crea el mock.
   const [loading, setLoading] = useState(false);
-  const [notice, setNotice] = useState('');
 
-  const tarifaTotal = useMemo(() => {
-    return Number(form.distancia_estimada_km || 0) * Number(form.tarifa_por_km || 0);
-  }, [form.distancia_estimada_km, form.tarifa_por_km]);
+  // Contrato registrado. Si existe, se muestra la pantalla final de exito.
+  const [registeredContrato, setRegisteredContrato] = useState<RegistroContratoSuccess | null>(null);
 
-  const update = (field: keyof Form, value: string) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
-    setErrors((prev) => ({ ...prev, [field]: '' }));
-    setNotice('');
+  // Tarifa total de la HU: Distancia Estimada x Tarifa por KM.
+  const tarifaTotal = useMemo(() => getRegistroTarifaTotal(form), [form]);
+
+  // Etiqueta legible del tipo de servicio para mostrar en el resumen lateral.
+  const tipoServicioLabel =
+    tipoServicioOptions.find((option) => option.value === form.tipo_servicio)?.label || '-';
+
+  /**
+   * Actualiza cualquier campo del formulario y limpia su error puntual.
+   * Mantiene feedback inmediato sin borrar errores de otros campos.
+   */
+  const update = (field: keyof RegistroContratoForm, value: string) => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setErrors((current) => ({ ...current, [field]: undefined }));
   };
 
-  const validarPaso1 = () => {
-    const nextErrors: Record<string, string> = {};
-
-    if (!form.cliente.trim()) nextErrors.cliente = 'Campo obligatorio';
-    if (!/^\d{11}$/.test(form.ruc)) {
-      nextErrors.ruc = 'El RUC debe tener 11 dígitos numéricos';
-    }
-    if (!form.tipo_servicio) nextErrors.tipo_servicio = 'Seleccione un tipo de servicio';
-    if (!form.fecha_inicio) nextErrors.fecha_inicio = 'Campo obligatorio';
-    if (!form.fecha_fin) nextErrors.fecha_fin = 'Campo obligatorio';
-    if (form.fecha_fin && form.fecha_inicio && form.fecha_fin <= form.fecha_inicio) {
-      nextErrors.fecha_fin = 'La fecha de fin debe ser posterior a la fecha de inicio';
-    }
-
-    setErrors(nextErrors);
-    return Object.keys(nextErrors).length === 0;
-  };
-
-  const validarPaso2 = () => {
-    const nextErrors: Record<string, string> = {};
-
-    if (!form.origen.trim()) nextErrors.origen = 'Campo obligatorio';
-    if (!form.destino.trim()) nextErrors.destino = 'Campo obligatorio';
-    if (Number(form.distancia_estimada_km) <= 0) {
-      nextErrors.distancia_estimada_km = 'La distancia debe ser mayor a 0';
-    }
-
-    setErrors(nextErrors);
-    return Object.keys(nextErrors).length === 0;
-  };
-
-  const validarPaso3 = () => {
-    const nextErrors: Record<string, string> = {};
-
-    if (Number(form.tarifa_por_km) <= 0) nextErrors.tarifa_por_km = 'Debe ser mayor a 0';
-    if (form.tarifa_por_hora === '') nextErrors.tarifa_por_hora = 'Campo obligatorio';
-    if (Number(form.tarifa_por_hora) < 0) nextErrors.tarifa_por_hora = 'No puede ser negativo';
-    if (form.tarifa_espera === '') nextErrors.tarifa_espera = 'Campo obligatorio';
-    if (Number(form.tarifa_espera) < 0) nextErrors.tarifa_espera = 'No puede ser negativo';
-
-    setErrors(nextErrors);
-    return Object.keys(nextErrors).length === 0;
-  };
-
+  /**
+   * Avanza al siguiente paso solo si el paso actual cumple sus criterios.
+   */
   const next = () => {
-    if (step === 1 && validarPaso1()) {
-      setStep(2);
-      setNotice('Información general validada correctamente');
-    }
-    if (step === 2 && validarPaso2()) {
-      setStep(3);
-      setNotice('Ruta de servicio validada correctamente');
-    }
+    const nextErrors = step === 1 ? validateGeneralStep(form) : validateRouteStep(form);
+    setErrors(nextErrors);
+
+    if (hasErrors(nextErrors)) return;
+
+    setStep((currentStep) => currentStep + 1);
   };
 
+  /**
+   * Registra el contrato en modo mock.
+   * Genera ID unico, tarifa total y devuelve el contrato a App.tsx mediante onRegistered.
+   */
   const registrar = async () => {
-    if (!validarPaso3()) return;
+    const nextErrors = validateRatesStep(form);
+    setErrors(nextErrors);
+    if (hasErrors(nextErrors)) return;
 
     setLoading(true);
-
     try {
-      const contrato = await crearContrato({
-        cliente: form.cliente.trim(),
-        ruc: form.ruc,
-        descripcion: form.descripcion.trim() || undefined,
-        tipo_servicio: form.tipo_servicio as TipoServicio,
-        fecha_inicio: form.fecha_inicio,
-        fecha_fin: form.fecha_fin,
-        origen: form.origen.trim(),
-        destino: form.destino.trim(),
-        distancia_estimada_km: Number(Number(form.distancia_estimada_km).toFixed(2)),
-        tarifa_por_km: Number(Number(form.tarifa_por_km).toFixed(2)),
-        tarifa_por_hora: Number(Number(form.tarifa_por_hora).toFixed(2)),
-        tarifa_espera: Number(Number(form.tarifa_espera).toFixed(2)),
-        moneda: 'PEN',
+      const contrato = await createMockContrato(form);
+      setRegisteredContrato({
+        id: contrato.id,
+        codigo: contrato.codigo,
+        estado: contrato.estado,
       });
-
       onRegistered?.(contrato);
-      onBack();
-    } catch (error) {
-      let errorMessage = 'No se pudo registrar el contrato';
-      if (error && typeof error === 'object') {
-        const err = error as Record<string, unknown>;
-        if ('response' in err && err.response && typeof err.response === 'object') {
-          const response = err.response as Record<string, unknown>;
-          if ('data' in response && response.data && typeof response.data === 'object') {
-            const data = response.data as Record<string, unknown>;
-            if ('message' in data && typeof data.message === 'string') {
-              errorMessage = data.message;
-            }
-          }
-        } else if ('message' in err && typeof err.message === 'string') {
-          errorMessage = err.message;
-        }
-      }
-      alert(errorMessage);
     } finally {
       setLoading(false);
     }
   };
 
-  return (
-    <main>
-      {notice && (
-        <div className="fixed right-4 top-24 z-20 rounded-lg border border-slate-200 bg-white px-5 py-3 text-sm font-semibold shadow-lg">
-          {notice}
-        </div>
-      )}
+  /**
+   * Reinicia la HU para registrar otro contrato sin salir de la pagina.
+   */
+  const startNewContract = () => {
+    setStep(1);
+    setForm(initialRegistroContratoForm);
+    setErrors({});
+    setRegisteredContrato(null);
+  };
 
-      <header className="mb-6 flex items-start gap-4">
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="Volver al listado"
-          className="grid h-10 w-10 shrink-0 place-items-center rounded-lg border border-slate-200 bg-white text-xl text-slate-700 shadow-sm hover:border-blue-300"
-        >
-          ←
-        </button>
-        <div>
-          <h1 className="text-3xl font-bold text-slate-950">Registro de Contrato</h1>
-          <p className="mt-1 text-slate-600">
-            Complete los siguientes pasos para registrar un nuevo contrato
-          </p>
-        </div>
+  return (
+    <main className="mx-auto max-w-6xl space-y-6">
+      {/* Breadcrumb y titulo orientados a la HU. */}
+      <header>
+        <p className="text-xs font-semibold text-blue-700">Contratos / Nuevo Contrato</p>
+        <h1 className="mt-3 text-2xl font-bold text-slate-950">Registrar Nuevo Contrato</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          HU16 - Complete los 3 pasos para crear el contrato y configurar tarifas
+        </p>
       </header>
 
-      <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
-        <Stepper step={step} />
+      {/* El stepper queda visible incluso en la pantalla final para mostrar el proceso completo. */}
+      <Stepper step={registeredContrato ? 4 : step} />
 
-        <div className="mt-8 min-h-[430px]">
+      {registeredContrato ? (
+        <SuccessState
+          contrato={registeredContrato}
+          onCreateAnother={startNewContract}
+          onViewContracts={onBack}
+        />
+      ) : (
+        <>
+          {/* Paso 1: cumple criterio de aceptacion 1. */}
           {step === 1 && (
-            <div className="grid gap-6">
-              <div className="grid gap-6 lg:grid-cols-2">
-                <Input
+            <StepCard
+              icon="ID"
+              title="Datos Generales del Contrato"
+              subtitle="Informacion del cliente y tipo de servicio"
+            >
+              <div className="space-y-6">
+                <SectionTitle>Informacion del cliente</SectionTitle>
+
+                <InputField
                   label="Nombre del Cliente"
                   required
                   value={form.cliente}
                   error={errors.cliente}
-                  placeholder="Ej: Empresa Constructora ABC S.A.C."
+                  placeholder="Ej: Distribuidora Nacional S.A.C."
                   onChange={(value) => update('cliente', value)}
                 />
 
-                <Input
-                  label="RUC"
-                  required
-                  value={form.ruc}
-                  error={errors.ruc}
-                  placeholder="11 dígitos numéricos"
-                  maxLength={11}
-                  helper={
-                    form.ruc.length === 11 && !errors.ruc
-                      ? 'RUC válido'
-                      : `${form.ruc.length}/11 dígitos`
-                  }
-                  success={form.ruc.length === 11 && !errors.ruc}
-                  onChange={(value) => update('ruc', value.replace(/\D/g, '').slice(0, 11))}
-                />
-              </div>
+                <div className="grid gap-5 lg:grid-cols-2">
+                  <InputField
+                    label="RUC"
+                    required
+                    value={form.ruc}
+                    error={errors.ruc}
+                    placeholder="Ej: 20123456789"
+                    maxLength={11}
+                    helper={
+                      form.ruc.length === 11 && !errors.ruc
+                        ? 'RUC valido'
+                        : `${form.ruc.length}/11 digitos`
+                    }
+                    success={form.ruc.length === 11 && !errors.ruc}
+                    onChange={(value) => update('ruc', value.replace(/\D/g, '').slice(0, 11))}
+                  />
 
-              <div className="grid gap-6 lg:grid-cols-2">
-                <label>
-                  <Label text="Tipo de Servicio" required />
-                  <select
+                  <SelectField
+                    label="Tipo de Servicio"
+                    required
                     value={form.tipo_servicio}
-                    onChange={(event) => update('tipo_servicio', event.target.value)}
-                    className="field-base"
-                  >
-                    <option value="POR_VIAJE">Por Viaje</option>
-                    <option value="POR_HORA">Por Hora</option>
-                    <option value="POR_TONELADA">Por Tonelada</option>
-                    <option value="POR_KM">Por Kilómetro</option>
-                    <option value="MENSUAL">Mensual</option>
-                  </select>
-                  {errors.tipo_servicio && <Error text={errors.tipo_servicio} />}
+                    options={tipoServicioOptions}
+                    error={errors.tipo_servicio}
+                    onChange={(value) => update('tipo_servicio', value)}
+                  />
+                </div>
+
+                <SectionTitle>Vigencia del contrato</SectionTitle>
+
+                <div className="grid gap-5 lg:grid-cols-2">
+                  <InputField
+                    type="date"
+                    label="Fecha de Inicio"
+                    required
+                    value={form.fecha_inicio}
+                    error={errors.fecha_inicio}
+                    onChange={(value) => update('fecha_inicio', value)}
+                  />
+
+                  <InputField
+                    type="date"
+                    label="Fecha de Vencimiento"
+                    required
+                    value={form.fecha_fin}
+                    error={errors.fecha_fin}
+                    onChange={(value) => update('fecha_fin', value)}
+                  />
+                </div>
+
+                <InlineNotice>
+                  Todos los campos marcados con * son obligatorios. El sistema validara el RUC y las fechas antes de avanzar.
+                </InlineNotice>
+              </div>
+            </StepCard>
+          )}
+
+          {/* Paso 2: cumple criterio de aceptacion 2. */}
+          {step === 2 && (
+            <StepCard
+              icon="PIN"
+              title="Configuracion de Ruta de Servicio"
+              subtitle="Define el origen, destino y distancia de la ruta"
+            >
+              <div className="space-y-6">
+                <SectionTitle>Puntos de ruta</SectionTitle>
+
+                <div className="grid gap-5 lg:grid-cols-2">
+                  <SelectField
+                    label="Punto de Partida"
+                    required
+                    value={form.origen}
+                    options={terminalOptions}
+                    error={errors.origen}
+                    onChange={(value) => update('origen', value)}
+                  />
+
+                  <SelectField
+                    label="Punto de Llegada"
+                    required
+                    value={form.destino}
+                    options={terminalOptions}
+                    error={errors.destino}
+                    onChange={(value) => update('destino', value)}
+                  />
+                </div>
+
+                <SectionTitle>Parametros de ruta</SectionTitle>
+
+                <div className="grid gap-5 lg:grid-cols-2">
+                  <InputField
+                    type="number"
+                    label="Distancia Estimada"
+                    required
+                    value={form.distancia_estimada_km}
+                    error={errors.distancia_estimada_km}
+                    placeholder="0"
+                    helper="Este valor se usara para detectar desvios de ruta via GPS"
+                    onChange={(value) => update('distancia_estimada_km', value)}
+                  />
+
+                  <InputField
+                    type="number"
+                    label="Tiempo Estimado de Viaje"
+                    value={form.tiempo_estimado_horas}
+                    placeholder="0"
+                    helper="Referencia orientativa, no obligatoria"
+                    onChange={(value) => update('tiempo_estimado_horas', value)}
+                  />
+                </div>
+
+                <label>
+                  <Label text="Observaciones de Ruta" />
+                  <textarea
+                    value={form.observaciones_ruta}
+                    placeholder="Ej: Ruta pasa por peaje Variante de Pasamayo..."
+                    onChange={(event) => update('observaciones_ruta', event.target.value)}
+                    className="field-base min-h-24 resize-y"
+                  />
                 </label>
 
-                <Input
-                  type="date"
-                  label="Fecha de Inicio"
-                  required
-                  value={form.fecha_inicio}
-                  error={errors.fecha_inicio}
-                  onChange={(value) => update('fecha_inicio', value)}
-                />
+                <InlineNotice>
+                  La distancia estimada se cruzara en tiempo real con los datos del modulo GPS para generar alertas automaticas.
+                </InlineNotice>
               </div>
-
-              <Input
-                type="date"
-                label="Fecha de Fin"
-                required
-                value={form.fecha_fin}
-                error={errors.fecha_fin}
-                onChange={(value) => update('fecha_fin', value)}
-              />
-
-              <label>
-                <Label text="Descripción del Servicio (Opcional)" />
-                <textarea
-                  value={form.descripcion}
-                  placeholder="Detalles adicionales del servicio..."
-                  onChange={(event) => update('descripcion', event.target.value)}
-                  className="field-base min-h-20 resize-y"
-                />
-              </label>
-            </div>
+            </StepCard>
           )}
 
-          {step === 2 && (
-            <div className="grid gap-6">
-              <Callout tone="blue" title="Información de Ruta">
-                Estos parámetros se utilizarán como referencia para el monitoreo de la flota y el
-                cálculo de tarifas.
-              </Callout>
-
-              <div className="grid gap-6 lg:grid-cols-2">
-                <Input
-                  label="Punto de Partida"
-                  required
-                  value={form.origen}
-                  error={errors.origen}
-                  placeholder="Ej: Av. Lima 123, Lima"
-                  onChange={(value) => update('origen', value)}
-                />
-
-                <Input
-                  label="Punto de Llegada"
-                  required
-                  value={form.destino}
-                  error={errors.destino}
-                  placeholder="Ej: Calle Arequipa 456, Callao"
-                  onChange={(value) => update('destino', value)}
-                />
-              </div>
-
-              <Input
-                type="number"
-                label="Distancia Estimada (Kilómetros)"
-                required
-                value={form.distancia_estimada_km}
-                error={errors.distancia_estimada_km}
-                placeholder="Ej: 25.50"
-                helper="Ingrese la distancia estimada entre el punto de partida y llegada"
-                onChange={(value) => update('distancia_estimada_km', value)}
-              />
-
-              {form.origen && form.destino && form.distancia_estimada_km && (
-                <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-5 text-emerald-900">
-                  <p className="font-bold">Vista previa de ruta</p>
-                  <p className="mt-1 text-sm">{form.origen} → {form.destino}</p>
-                  <p className="mt-3 text-2xl font-bold">{form.distancia_estimada_km} km</p>
-                </div>
-              )}
-            </div>
-          )}
-
+          {/* Paso 3: cumple criterio de aceptacion 3 y reglas de negocio de tarifas. */}
           {step === 3 && (
-            <div className="grid gap-6">
-              <Callout tone="amber" title="Configuración de Tarifas">
-                Todas las tarifas se guardan en Soles (S/) con dos decimales. La Tarifa Total se
-                calcula como: Distancia Estimada × Tarifa por KM.
-              </Callout>
+            <StepCard
+              icon="S/"
+              title="Definicion de Reglas de Tarifa"
+              subtitle="Configura las tarifas en Soles (S/) con hasta 2 decimales"
+            >
+              <div className="grid gap-6 lg:grid-cols-[1fr_260px]">
+                <div className="space-y-6">
+                  <div className="grid gap-5 md:grid-cols-3">
+                    <MoneyInput
+                      label="Tarifa por KM"
+                      value={form.tarifa_por_km}
+                      error={errors.tarifa_por_km}
+                      helper="S/ por kilometro"
+                      onChange={(value) => update('tarifa_por_km', value)}
+                    />
 
-              <div className="grid gap-6 xl:grid-cols-3">
-                <MoneyInput
-                  label="Tarifa por KM"
-                  value={form.tarifa_por_km}
-                  error={errors.tarifa_por_km}
-                  helper="Costo por kilómetro recorrido"
-                  onChange={(value) => update('tarifa_por_km', value)}
-                />
+                    <MoneyInput
+                      label="Tarifa por Hora"
+                      value={form.tarifa_por_hora}
+                      error={errors.tarifa_por_hora}
+                      helper="S/ por hora de viaje"
+                      onChange={(value) => update('tarifa_por_hora', value)}
+                    />
 
-                <MoneyInput
-                  label="Tarifa por Hora"
-                  value={form.tarifa_por_hora}
-                  error={errors.tarifa_por_hora}
-                  helper="Costo por hora de servicio"
-                  onChange={(value) => update('tarifa_por_hora', value)}
-                />
+                    <MoneyInput
+                      label="Tarifa por Espera"
+                      value={form.tarifa_espera}
+                      error={errors.tarifa_espera}
+                      helper="S/ por hora de espera"
+                      onChange={(value) => update('tarifa_espera', value)}
+                    />
+                  </div>
 
-                <MoneyInput
-                  label="Tarifa por Espera"
-                  value={form.tarifa_espera}
-                  error={errors.tarifa_espera}
-                  helper="Costo por tiempo de espera"
-                  onChange={(value) => update('tarifa_espera', value)}
+                  <InlineNotice>
+                    Las tarifas se registran en Soles (S/) y aceptan hasta 2 decimales. Al guardar se generara un ID unico y estado Activo.
+                  </InlineNotice>
+
+                  <div className="rounded-lg border border-blue-200 bg-blue-50 p-5 text-blue-900">
+                    <p className="text-sm font-semibold">Tarifa Total inicial</p>
+                    <p className="mt-2 text-sm">
+                      {form.distancia_estimada_km || 0} km x S/ {Number(form.tarifa_por_km || 0).toFixed(2)} por km
+                    </p>
+                    <p className="mt-4 text-3xl font-bold">S/ {tarifaTotal.toFixed(2)}</p>
+                  </div>
+                </div>
+
+                <ContractSummaryPanel
+                  cliente={form.cliente}
+                  ruc={form.ruc}
+                  tipo={tipoServicioLabel}
+                  inicio={form.fecha_inicio}
+                  fin={form.fecha_fin}
+                  origen={form.origen}
+                  destino={form.destino}
+                  distancia={form.distancia_estimada_km}
+                  tarifaKm={form.tarifa_por_km}
+                  tarifaHora={form.tarifa_por_hora}
+                  tarifaEspera={form.tarifa_espera}
                 />
               </div>
-
-              {Number(form.tarifa_por_km) > 0 && (
-                <div className="rounded-lg border border-blue-200 bg-blue-50 p-5 text-blue-900">
-                  <p className="font-semibold">Cálculo Automático:</p>
-                  <p className="mt-2 text-sm">
-                    {form.distancia_estimada_km} km × S/ {Number(form.tarifa_por_km).toFixed(2)} /km
-                  </p>
-                  <p className="mt-4 text-3xl font-bold">Tarifa Total: S/ {tarifaTotal.toFixed(2)}</p>
-                </div>
-              )}
-
-              <div className="rounded-xl border border-slate-100 bg-white p-6 shadow-md">
-                <h3 className="mb-6 text-lg font-bold">Resumen del Contrato</h3>
-                <div className="grid gap-6 md:grid-cols-2">
-                  <Summary label="Cliente" value={form.cliente} />
-                  <Summary label="RUC" value={form.ruc} />
-                  <Summary label="Ruta" value={`${form.origen} → ${form.destino}`} />
-                  <Summary label="Distancia" value={`${form.distancia_estimada_km} km`} />
-                  <Summary label="Vigencia" value={`${form.fecha_inicio} - ${form.fecha_fin}`} />
-                  <Summary label="Tarifa Total" value={`S/ ${tarifaTotal.toFixed(2)}`} highlight />
-                </div>
-              </div>
-            </div>
+            </StepCard>
           )}
-        </div>
 
-        <footer className="mt-8 flex flex-col gap-4 border-t border-slate-200 pt-6 sm:flex-row sm:items-center sm:justify-between">
-          <button
-            type="button"
-            disabled={step === 1}
-            onClick={() => setStep((currentStep) => currentStep - 1)}
-            className="rounded-lg border border-slate-200 bg-white px-5 py-3 font-semibold text-slate-700 hover:border-blue-300 disabled:opacity-40"
-          >
-            ← Anterior
-          </button>
-
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <span className="text-sm text-slate-500">Paso {step} de 3</span>
+          {/* Navegacion del wizard: cancelar, anterior, siguiente y registrar. */}
+          <footer className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              {step > 1 && (
+                <button
+                  type="button"
+                  onClick={() => setStep((currentStep) => currentStep - 1)}
+                  className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:border-blue-300"
+                >
+                  {'<-'} Anterior
+                </button>
+              )}
+              <button type="button" onClick={onBack} className="px-3 py-2 text-sm font-semibold text-red-600">
+                x Cancelar
+              </button>
+            </div>
 
             {step < 3 ? (
               <button
                 type="button"
                 onClick={next}
-                className="rounded-lg bg-blue-600 px-5 py-3 font-semibold text-white hover:bg-blue-700"
+                className="rounded-lg bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-blue-700"
               >
-                Siguiente →
+                Siguiente: {step === 1 ? 'Ruta de Servicio' : 'Reglas de Tarifa'} {'->'}
               </button>
             ) : (
               <button
                 type="button"
                 disabled={loading}
                 onClick={registrar}
-                className="rounded-lg bg-emerald-600 px-5 py-3 font-semibold text-white hover:bg-emerald-700 disabled:opacity-60"
+                className="rounded-lg bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 disabled:opacity-60"
               >
                 {loading ? 'Registrando...' : 'Registrar Contrato'}
               </button>
             )}
-          </div>
-        </footer>
-      </section>
+          </footer>
+        </>
+      )}
     </main>
   );
 }
 
-function Stepper({ step }: { step: number }) {
-  const items = ['Información General', 'Ruta de Servicio', 'Tarifas'];
-
-  return (
-    <div className="grid gap-5 sm:grid-cols-3">
-      {items.map((item, index) => {
-        const number = index + 1;
-        const active = step === number;
-        const done = step > number;
-
-        return (
-          <div key={item} className="relative flex flex-col items-center text-center">
-            {index < items.length - 1 && (
-              <div
-                className={`absolute left-[60%] top-6 hidden h-1 w-[80%] rounded-full sm:block ${
-                  step > number ? 'bg-emerald-500' : 'bg-slate-200'
-                }`}
-              />
-            )}
-
-            <div
-              className={`z-10 grid h-12 w-12 place-items-center rounded-full text-xl font-bold ${
-                done
-                  ? 'bg-emerald-500 text-white'
-                  : active
-                    ? 'bg-blue-600 text-white ring-4 ring-blue-100'
-                    : 'bg-slate-200 text-slate-500'
-              }`}
-            >
-              {done ? '✓' : number === 3 ? '$' : number}
-            </div>
-
-            <p
-              className={`mt-2 text-xs font-semibold ${
-                done ? 'text-emerald-700' : active ? 'text-blue-700' : 'text-slate-500'
-              }`}
-            >
-              {item}
-            </p>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function Callout({
-  title,
-  children,
-  tone,
+function SuccessState({
+  contrato,
+  onCreateAnother,
+  onViewContracts,
 }: {
-  title: string;
-  children: string;
-  tone: 'blue' | 'amber';
-}) {
-  const styles =
-    tone === 'blue'
-      ? 'border-blue-200 bg-blue-50 text-blue-900'
-      : 'border-amber-200 bg-amber-50 text-amber-900';
-
-  return (
-    <div className={`rounded-lg border p-5 ${styles}`}>
-      <h3 className="font-bold">{title}</h3>
-      <p className="mt-2 text-sm">{children}</p>
-    </div>
-  );
-}
-
-function Label({ text, required }: { text: string; required?: boolean }) {
-  return (
-    <span className="mb-1.5 block text-sm font-bold">
-      {text} {required && <span className="text-red-500">*</span>}
-    </span>
-  );
-}
-
-function Input(props: {
-  label: string;
-  value: string;
-  onChange: (value: string) => void;
-  error?: string;
-  type?: string;
-  placeholder?: string;
-  helper?: string;
-  maxLength?: number;
-  required?: boolean;
-  success?: boolean;
+  contrato: RegistroContratoSuccess;
+  onCreateAnother: () => void;
+  onViewContracts: () => void;
 }) {
   return (
-    <label>
-      <Label text={props.label} required={props.required} />
-      <input
-        type={props.type || 'text'}
-        value={props.value}
-        placeholder={props.placeholder}
-        maxLength={props.maxLength}
-        onChange={(event) => props.onChange(event.target.value)}
-        className={`field-base ${
-          props.error
-            ? 'border-red-500 focus:ring-red-100'
-            : props.success
-              ? 'border-emerald-500 focus:ring-emerald-100'
-              : 'border-transparent focus:ring-blue-100'
-        }`}
-      />
-      {props.helper && !props.error && (
-        <p className={`mt-1.5 text-xs ${props.success ? 'text-emerald-700' : 'text-slate-500'}`}>
-          {props.success ? '✓ ' : ''}
-          {props.helper}
-        </p>
-      )}
-      {props.error && <Error text={props.error} />}
-    </label>
-  );
-}
-
-function MoneyInput(props: {
-  label: string;
-  value: string;
-  onChange: (value: string) => void;
-  error?: string;
-  helper?: string;
-}) {
-  return (
-    <label>
-      <Label text={props.label} required />
-      <div
-        className={`flex overflow-hidden rounded-lg border bg-slate-100 focus-within:bg-white focus-within:ring-2 ${
-          props.error
-            ? 'border-red-500 focus-within:ring-red-100'
-            : 'border-transparent focus-within:ring-blue-100'
-        }`}
-      >
-        <span className="px-4 py-3 font-semibold text-slate-600">S/</span>
-        <input
-          type="number"
-          step="0.01"
-          min="0"
-          value={props.value}
-          placeholder="0.00"
-          onChange={(event) => props.onChange(event.target.value)}
-          className="w-full border-0 bg-transparent px-2 py-3 outline-none"
-        />
+    <section className="rounded-lg border border-slate-200 bg-white px-6 py-14 text-center shadow-sm">
+      <div className="mx-auto grid h-16 w-16 place-items-center rounded-full bg-emerald-100 text-2xl font-bold text-emerald-700">
+        OK
       </div>
-      {props.helper && !props.error && <p className="mt-1.5 text-xs text-slate-500">{props.helper}</p>}
-      {props.error && <Error text={props.error} />}
-    </label>
-  );
-}
+      <h2 className="mt-6 text-2xl font-bold text-slate-950">Contrato registrado exitosamente</h2>
+      <p className="mx-auto mt-2 max-w-md text-sm text-slate-500">
+        El contrato ha sido creado y esta disponible en el sistema mock para asociar jornadas y registrar kilometrajes.
+      </p>
 
-function Error({ text }: { text: string }) {
-  return <p className="mt-1.5 text-sm font-medium text-red-600">ⓘ {text}</p>;
-}
+      <div className="mx-auto mt-6 inline-flex items-center gap-5 rounded-lg border border-blue-200 bg-blue-50 px-6 py-4">
+        <div className="text-left">
+          <p className="text-[10px] font-bold uppercase text-blue-700">ID de contrato generado</p>
+          <p className="text-xl font-bold text-blue-700">{contrato.codigo || contrato.id}</p>
+        </div>
+        <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-bold text-emerald-700">
+          {contrato.estado || 'Activo'}
+        </span>
+      </div>
 
-function Summary({
-  label,
-  value,
-  highlight,
-}: {
-  label: string;
-  value: string;
-  highlight?: boolean;
-}) {
-  return (
-    <div>
-      <p className="text-sm text-slate-500">{label}</p>
-      <p className={highlight ? 'text-2xl font-bold text-blue-700' : 'font-bold'}>{value || '-'}</p>
-    </div>
+      <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+        <button
+          type="button"
+          onClick={onCreateAnother}
+          className="rounded-lg border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-700 hover:border-blue-300"
+        >
+          + Nuevo Contrato
+        </button>
+        <button
+          type="button"
+          onClick={onViewContracts}
+          className="rounded-lg bg-blue-600 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-700"
+        >
+          Ver todos los contratos
+        </button>
+      </div>
+    </section>
   );
 }

--- a/apps/mfe-contratos/src/modules/registro-contrato/types.ts
+++ b/apps/mfe-contratos/src/modules/registro-contrato/types.ts
@@ -1,0 +1,34 @@
+import type { Contrato, TipoServicio } from '@nanutech/api-client';
+
+// Props que recibe la pagina desde App.tsx.
+// onRegistered permite que App muestre el toast y refresque flujo cuando se cree el contrato.
+export type RegistroContratoPageProps = {
+  onBack: () => void;
+  onRegistered?: (contrato: Contrato) => void;
+};
+
+// Contrato creado en modo mock. Se guarda para mostrar la pantalla de exito sin salir del modulo.
+export type RegistroContratoSuccess = Pick<Contrato, 'id' | 'codigo' | 'estado'>;
+
+// Modelo interno del formulario.
+// Los numeros viven como string porque los inputs HTML controlados trabajan mejor asi.
+export type RegistroContratoForm = {
+  cliente: string;
+  ruc: string;
+  tipo_servicio: TipoServicio | '';
+  fecha_inicio: string;
+  fecha_fin: string;
+  descripcion: string;
+  origen: string;
+  destino: string;
+  distancia_estimada_km: string;
+  tiempo_estimado_horas: string;
+  observaciones_ruta: string;
+  tarifa_por_km: string;
+  tarifa_por_hora: string;
+  tarifa_por_tonelada: string;
+  tarifa_espera: string;
+};
+
+// Errores por campo. Partial permite guardar solo los campos que realmente fallaron.
+export type RegistroContratoErrors = Partial<Record<keyof RegistroContratoForm, string>>;

--- a/apps/mfe-contratos/src/modules/registro-contrato/utils/dateUtils.ts
+++ b/apps/mfe-contratos/src/modules/registro-contrato/utils/dateUtils.ts
@@ -1,0 +1,10 @@
+// Devuelve la fecha actual en formato YYYY-MM-DD para input type="date".
+// Se arma con getters locales para no depender de toISOString, que puede mover el dia por zona horaria.
+export const getTodayLocal = () => {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};

--- a/apps/mfe-contratos/src/modules/registro-contrato/utils/registroContratoMapper.ts
+++ b/apps/mfe-contratos/src/modules/registro-contrato/utils/registroContratoMapper.ts
@@ -1,0 +1,31 @@
+import type { TipoServicio } from '@nanutech/api-client';
+import type { RegistroContratoForm } from '../types';
+
+// Normaliza strings numericos a numero con dos decimales.
+// Esto evita ruido de precision decimal al mostrar o guardar montos.
+export const toMoneyNumber = (value: string) => Number(Number(value || 0).toFixed(2));
+
+/**
+ * Traduce el formulario editable al shape que espera crear contrato.
+ * Hoy lo consume el repositorio mock; luego puede enviarse al API sin cambiar la pagina.
+ */
+export const buildCrearContratoPayload = (form: RegistroContratoForm) => ({
+  cliente: form.cliente.trim(),
+  ruc: form.ruc,
+  descripcion: form.descripcion.trim() || undefined,
+  tipo_servicio: form.tipo_servicio as TipoServicio,
+  fecha_inicio: form.fecha_inicio,
+  fecha_fin: form.fecha_fin,
+  origen: form.origen.trim(),
+  destino: form.destino.trim(),
+  distancia_estimada_km: toMoneyNumber(form.distancia_estimada_km),
+  tarifa_por_km: toMoneyNumber(form.tarifa_por_km),
+  tarifa_por_hora: toMoneyNumber(form.tarifa_por_hora),
+  tarifa_por_tonelada: toMoneyNumber(form.tarifa_por_tonelada),
+  tarifa_espera: toMoneyNumber(form.tarifa_espera),
+  moneda: 'PEN' as const,
+});
+
+// Tarifa referencial principal usada en el resumen.
+export const getRegistroTarifaTotal = (form: RegistroContratoForm) =>
+  toMoneyNumber(String(Number(form.distancia_estimada_km || 0) * Number(form.tarifa_por_km || 0)));

--- a/apps/mfe-contratos/src/modules/registro-contrato/utils/registroContratoValidators.ts
+++ b/apps/mfe-contratos/src/modules/registro-contrato/utils/registroContratoValidators.ts
@@ -1,0 +1,49 @@
+import type { RegistroContratoErrors, RegistroContratoForm } from '../types';
+
+// Valida el primer paso: datos comerciales y vigencia.
+export const validateGeneralStep = (form: RegistroContratoForm): RegistroContratoErrors => {
+  const errors: RegistroContratoErrors = {};
+
+  if (!form.cliente.trim()) errors.cliente = 'Campo obligatorio';
+  if (!/^\d{11}$/.test(form.ruc)) errors.ruc = 'El RUC debe tener 11 digitos numericos';
+  if (!form.tipo_servicio) errors.tipo_servicio = 'Seleccione un tipo de servicio';
+  if (!form.fecha_inicio) errors.fecha_inicio = 'Campo obligatorio';
+  if (!form.fecha_fin) errors.fecha_fin = 'Campo obligatorio';
+  if (form.fecha_fin && form.fecha_inicio && form.fecha_fin <= form.fecha_inicio) {
+    errors.fecha_fin = 'La fecha de fin debe ser posterior a la fecha de inicio';
+  }
+
+  return errors;
+};
+
+// Valida el segundo paso: origen, destino y distancia operativa.
+export const validateRouteStep = (form: RegistroContratoForm): RegistroContratoErrors => {
+  const errors: RegistroContratoErrors = {};
+
+  if (!form.origen.trim()) errors.origen = 'Campo obligatorio';
+  if (!form.destino.trim()) errors.destino = 'Campo obligatorio';
+  if (Number(form.distancia_estimada_km) <= 0) {
+    errors.distancia_estimada_km = 'La distancia debe ser mayor a 0';
+  }
+
+  return errors;
+};
+
+// Valida el tercer paso: tarifas obligatorias y montos no negativos.
+export const validateRatesStep = (form: RegistroContratoForm): RegistroContratoErrors => {
+  const errors: RegistroContratoErrors = {};
+
+  if (Number(form.tarifa_por_km) <= 0) errors.tarifa_por_km = 'Debe ser mayor a 0';
+  if (form.tarifa_por_hora === '') errors.tarifa_por_hora = 'Campo obligatorio';
+  if (Number(form.tarifa_por_hora) < 0) errors.tarifa_por_hora = 'No puede ser negativo';
+  if (form.tarifa_por_tonelada !== '' && Number(form.tarifa_por_tonelada) < 0) {
+    errors.tarifa_por_tonelada = 'No puede ser negativo';
+  }
+  if (form.tarifa_espera === '') errors.tarifa_espera = 'Campo obligatorio';
+  if (Number(form.tarifa_espera) < 0) errors.tarifa_espera = 'No puede ser negativo';
+
+  return errors;
+};
+
+// Helper para que las paginas no repitan Object.keys(...).length.
+export const hasErrors = (errors: RegistroContratoErrors) => Object.keys(errors).length > 0;


### PR DESCRIPTION
## Descripción

Se documenta y refactoriza el módulo HU14 - Registro de Nuevo Contrato y Reglas de Tarifa dentro de `mfe-contratos`.

## Cambios realizados

- Se separó `RegistroContratoPage.tsx` en componentes, utilidades, mocks, constantes y tipos.
- Se agregaron comentarios explicativos en la lógica principal y archivos del módulo.
- Se implementó flujo mock-first para registrar contratos mientras el backend aún no está disponible.
- Se agregó generación de ID único de contrato en modo mock.
- Se validó RUC estrictamente con 11 dígitos numéricos.
- Se validaron campos obligatorios de cliente, RUC, tipo de servicio, vigencia, ruta y tarifas.
- Se agregó cálculo inicial de Tarifa Total como distancia estimada por tarifa por KM.
- Se actualizó la prueba unitaria de `RegistroContratoPage`.

## Validación

- `npm run build -w apps/mfe-contratos`
- `npm run test -w apps/mfe-contratos`
- `npm run test:all`

Las pruebas del módulo `mfe-contratos` se ejecutaron correctamente.

> Nota: `npm run test:all` ejecuta todos los workspaces. El módulo `mfe-contratos` pasa correctamente; cualquier error externo en otros workspaces no corresponde a HU14.

#61 