### PR TITLE
fix: HU14 - Registro de Nuevo Contrato y Reglas de Tarifa

### DIFF
--- a/apps/mfe-contratos/__tests__/unit/hu14-registro-contrato/RegistroContratoPage.test.tsx
+++ b/apps/mfe-contratos/__tests__/unit/hu14-registro-contrato/RegistroContratoPage.test.tsx
@@ -1,6 +1,13 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { crearContrato } from '@nanutech/api-client';
 import RegistroContratoPage from '../../../src/modules/registro-contrato/pages/RegistroContratoPage';
+
+vi.mock('@nanutech/api-client', () => ({
+  crearContrato: vi.fn(),
+}));
+
+const crearContratoMock = vi.mocked(crearContrato);
 
 const completarPasoInformacionGeneral = () => {
   fireEvent.change(screen.getByLabelText(/Nombre del Cliente/i), {
@@ -52,7 +59,29 @@ const avanzarAlPasoTarifas = () => {
   fireEvent.click(screen.getByRole('button', { name: /Siguiente/i }));
 };
 
-describe('RegistroContratoPage - HU14 mock-first', () => {
+describe('RegistroContratoPage - HU14 backend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    crearContratoMock.mockResolvedValue({
+      id: 'contrato-1',
+      codigo: 'CTR-2026-001',
+      cliente: 'Empresa Constructora ABC S.A.C.',
+      ruc: '20123456789',
+      tipo_servicio: 'POR_KM',
+      fecha_inicio: '2026-06-01',
+      fecha_fin: '2026-12-31',
+      origen: 'Lima - Terminal Ate',
+      destino: 'Lima - Terminal Callao',
+      distancia_estimada_km: 25.5,
+      tarifa_por_km: 3.2,
+      tarifa_por_hora: 50,
+      tarifa_espera: 12.5,
+      tarifa: 81.6,
+      moneda: 'PEN',
+      estado: 'VIGENTE',
+    });
+  });
+
   it('renderiza el primer paso del registro de contrato', () => {
     render(<RegistroContratoPage onBack={vi.fn()} />);
 
@@ -97,7 +126,7 @@ describe('RegistroContratoPage - HU14 mock-first', () => {
     expect(screen.getByText('20123456789')).toBeTruthy();
   });
 
-  it('crea un contrato mock y muestra el estado final exitoso', async () => {
+  it('registra el contrato en backend y muestra el estado final exitoso', async () => {
     const onBack = vi.fn();
     const onRegistered = vi.fn();
 
@@ -108,10 +137,20 @@ describe('RegistroContratoPage - HU14 mock-first', () => {
     fireEvent.click(screen.getByRole('button', { name: /Registrar Contrato/i }));
 
     await waitFor(() => {
+      expect(crearContrato).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cliente: 'Empresa Constructora ABC S.A.C.',
+          ruc: '20123456789',
+          tipo_servicio: 'POR_KM',
+          distancia_estimada_km: 25.5,
+          tarifa_por_km: 3.2,
+          moneda: 'PEN',
+        })
+      );
       expect(onRegistered).toHaveBeenCalledWith(
         expect.objectContaining({
           cliente: 'Empresa Constructora ABC S.A.C.',
-          codigo: expect.stringMatching(/^CTR-2026-/),
+          codigo: 'CTR-2026-001',
           tarifa: 81.6,
         })
       );
@@ -128,7 +167,28 @@ describe('RegistroContratoPage - HU14 mock-first', () => {
     fireEvent.click(screen.getByRole('button', { name: /Registrar Contrato/i }));
 
     expect(onRegistered).not.toHaveBeenCalled();
+    expect(crearContrato).not.toHaveBeenCalled();
     expect(screen.getByText(/Debe ser mayor a 0/i)).toBeTruthy();
     expect(screen.getAllByText(/Campo obligatorio/i)).toHaveLength(2);
   });
+
+  it('muestra error si el backend rechaza el registro', async () => {
+    crearContratoMock.mockRejectedValue({
+      response: {
+        data: {
+          message: 'RUC ya registrado',
+        },
+      },
+    });
+
+    render(<RegistroContratoPage onBack={vi.fn()} onRegistered={vi.fn()} />);
+
+    avanzarAlPasoTarifas();
+    completarPasoTarifas();
+    fireEvent.click(screen.getByRole('button', { name: /Registrar Contrato/i }));
+
+    expect(await screen.findByText('RUC ya registrado')).toBeTruthy();
+    expect(screen.queryByText(/Contrato registrado exitosamente/i)).toBeNull();
+  });
 });
+

--- a/apps/mfe-contratos/__tests__/unit/hu16-dashboard-gerencial/DashboardGerencial.test.tsx
+++ b/apps/mfe-contratos/__tests__/unit/hu16-dashboard-gerencial/DashboardGerencial.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { getDashboardGerencial } from '@nanutech/api-client';
+import DashboardGerencial from '../../../src/modules/dashboard-gerencial/pages/DashboardGerencial';
+
+vi.mock('@nanutech/api-client', () => ({
+  getDashboardGerencial: vi.fn(),
+}));
+
+describe('DashboardGerencial', () => {
+  it('muestra datos referenciales cuando falla el endpoint gerencial', async () => {
+    vi.mocked(getDashboardGerencial).mockRejectedValue(new Error('API no disponible'));
+
+    render(<DashboardGerencial />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Dashboard Gerencial')).not.toBeNull();
+    });
+
+    expect(screen.getByText(/No se pudo conectar con \/dashboard\/gerencial/i)).not.toBeNull();
+    expect(screen.getByText('Datos referenciales')).not.toBeNull();
+    expect(screen.getByText('Jornadas')).not.toBeNull();
+  });
+});

--- a/apps/mfe-contratos/src/App.tsx
+++ b/apps/mfe-contratos/src/App.tsx
@@ -1,23 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import {
-  Navigate,
-  Route,
-  Routes,
-  NavLink,
-} from 'react-router-dom';
+import { Navigate, NavLink, Route, Routes } from 'react-router-dom';
 
 import type { Contrato } from '@nanutech/api-client';
 
 import './App.css';
 
-/* Pages */
 import RegistroContratoPage from './modules/registro-contrato/pages/RegistroContratoPage';
 import { GestionContratosPage as ContratosPage } from './modules/gestion-contratos';
 import { DetalleContratoPage } from './modules/detalle-contrato';
 import { DashboardGerencial } from './modules/dashboard-gerencial';
-
-/* Seguimiento (si existe, si no se usa fallback) */
 import SeguimientoJornadas from './modules/seguimiento-jornadas/SeguimientoJornadas';
 
 type Toast = {
@@ -25,7 +17,6 @@ type Toast = {
   message: string;
 };
 
-/* FORMATOS */
 const formatDate = (date: Date) =>
   new Intl.DateTimeFormat('es-PE', {
     weekday: 'long',
@@ -43,17 +34,27 @@ const formatTime = (date: Date) =>
     .format(date)
     .replace(/\s/g, ' ');
 
-/* =========================
-   LAYOUT
-========================= */
-function AppShell({
-  children,
-  toast,
-}: {
-  children: ReactNode;
-  toast: Toast | null;
-}) {
+const getStoredUser = () => {
+  const storedUser = localStorage.getItem('nanutech_user');
+
+  if (!storedUser) {
+    return { name: 'Maria Gerente', email: 'gerente@nanutech.com' };
+  }
+
+  try {
+    const parsed = JSON.parse(storedUser) as { name?: string; nombre?: string; email?: string };
+    return {
+      name: parsed.name || parsed.nombre || 'Maria Gerente',
+      email: parsed.email || 'gerente@nanutech.com',
+    };
+  } catch {
+    return { name: 'Maria Gerente', email: 'gerente@nanutech.com' };
+  }
+};
+
+function AppShell({ children, toast }: { children: ReactNode; toast: Toast | null }) {
   const [now, setNow] = useState(() => new Date());
+  const [showSessionMenu, setShowSessionMenu] = useState(false);
 
   useEffect(() => {
     const timer = window.setInterval(() => setNow(new Date()), 30000);
@@ -61,62 +62,99 @@ function AppShell({
   }, []);
 
   const today = useMemo(() => formatDate(now), [now]);
+  const user = useMemo(() => getStoredUser(), []);
+
+  const handleLogout = () => {
+    localStorage.removeItem('nanutech_token');
+    localStorage.removeItem('nanutech_id_token');
+    localStorage.removeItem('nanutech_user');
+    localStorage.removeItem('nanutech_role');
+    localStorage.removeItem('nanutech_expires_at');
+    window.location.replace('/login');
+  };
 
   return (
     <div className="min-h-screen bg-slate-100 text-slate-950">
-
-      {/* SIDEBAR */}
       <aside className="fixed inset-y-0 left-0 z-20 hidden w-64 flex-col bg-slate-900 text-white lg:flex">
-
         <div className="flex h-[84px] items-center gap-3 border-b border-white/10 px-6">
           <div className="grid h-10 w-10 place-items-center rounded-lg bg-blue-600 font-bold">
             N
           </div>
           <div>
             <p className="text-lg font-bold">NANU TECH</p>
-            <p className="text-xs text-slate-300">Gestión de Flota</p>
+            <p className="text-xs text-slate-300">Gestion de Flota</p>
           </div>
         </div>
 
         <nav className="flex-1 space-y-2 px-4 py-6">
-          <NavItem label="Dashboard Gerencial" to="dashboard" />
-          <NavItem label="Contratos" to="." />
-          <NavItem label="Historial de Jornadas" to="historial" />
-          <NavItem label="Seguimiento Jornadas" to="seguimiento-jornadas" />
+          <NavItem label="Dashboard Gerencial" to="dashboard" end />
+          <NavItem label="Contratos" to="." end />
+          <NavItem label="Historial de Jornadas" to="historial" end />
+          <NavItem label="Seguimiento Jornadas" to="seguimiento-jornadas" end />
         </nav>
 
-        {/* ✅ SOLO AGREGADO - BLOQUE MARÍA GERENTE */}
-        <div className="space-y-4 border-t border-white/10 p-4">
+        <div className="relative space-y-4 border-t border-white/10 p-4">
+          {showSessionMenu && (
+            <div className="absolute bottom-[86px] left-5 right-5 overflow-hidden rounded-xl border border-slate-200 bg-white text-slate-900 shadow-xl">
+              <div className="border-b border-slate-100 px-5 py-4">
+                <p className="text-sm text-slate-500">Sesion iniciada como</p>
+                <p className="truncate text-sm font-bold">{user.email}</p>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="flex w-full items-center gap-3 px-5 py-4 text-left text-sm font-semibold text-red-500 transition hover:bg-red-50"
+              >
+                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                  <polyline points="16 17 21 12 16 7" />
+                  <line x1="21" y1="12" x2="9" y2="12" />
+                </svg>
+                Cerrar Sesion
+              </button>
+            </div>
+          )}
 
           <div className="rounded-lg border border-white/10 bg-white/5 p-4 text-sm">
-            <p className="text-slate-300">Sesión activa</p>
+            <p className="text-slate-300">Sesion activa</p>
             <p className="mt-1 font-bold">1h 35m</p>
           </div>
 
-          <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setShowSessionMenu((current) => !current)}
+            className="flex w-full items-center gap-3 rounded-lg text-left transition hover:bg-white/5"
+          >
             <div className="grid h-10 w-10 place-items-center rounded-full bg-blue-600 font-semibold">
-              M
+              {user.name.charAt(0).toUpperCase()}
             </div>
-            <div>
-              <p className="text-sm font-bold">María Gerente</p>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-bold">{user.name}</p>
               <p className="text-xs text-slate-300">Gerente de Operaciones</p>
             </div>
-          </div>
-
+            <svg
+              className={`h-4 w-4 shrink-0 text-slate-400 transition-transform ${showSessionMenu ? 'rotate-180' : ''}`}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
         </div>
-
       </aside>
 
-      {/* MAIN */}
       <div className="lg:pl-64">
         <header className="sticky top-0 z-10 flex h-[84px] items-center justify-between border-b border-slate-200 bg-white px-4 sm:px-8">
           <div>
-            <h1 className="text-2xl font-bold">Sistema de Gestión</h1>
+            <h1 className="text-2xl font-bold">Sistema de Gestion</h1>
             <p className="text-sm text-slate-500">{today}</p>
           </div>
 
           <div className="text-right text-xs text-slate-500">
-            <p>Última actualización</p>
+            <p>Ultima actualizacion</p>
             <p className="font-bold text-slate-950">{formatTime(now)}</p>
           </div>
         </header>
@@ -126,11 +164,10 @@ function AppShell({
         </div>
 
         <footer className="border-t border-slate-200 bg-white px-4 py-3 text-center text-xs text-slate-500 sm:px-8">
-          © 2026 NANU TECH
+          2026 NANU TECH
         </footer>
       </div>
 
-      {/* TOAST */}
       {toast && (
         <div className="fixed right-4 top-5 z-30 w-[360px] rounded-lg border bg-white p-4 shadow-lg">
           <p className="font-semibold">{toast.title}</p>
@@ -141,17 +178,11 @@ function AppShell({
   );
 }
 
-/* NAV ITEM */
-function NavItem({
-  label,
-  to,
-}: {
-  label: string;
-  to: string;
-}) {
+function NavItem({ label, to, end }: { label: string; to: string; end?: boolean }) {
   return (
     <NavLink
       to={to}
+      end={end}
       className={({ isActive }) =>
         `block rounded-lg px-4 py-3 text-sm font-semibold transition ${
           isActive
@@ -165,7 +196,6 @@ function NavItem({
   );
 }
 
-/* ROUTES (NO TOCADO) */
 export function AppRoutes() {
   const [showRegistro, setShowRegistro] = useState(false);
   const [selectedContratoId, setSelectedContratoId] = useState<string | null>(null);
@@ -210,18 +240,7 @@ export function AppRoutes() {
 
         <Route path="dashboard" element={<DashboardGerencial />} />
         <Route path="historial" element={<div>Historial de Jornadas</div>} />
-
-        <Route
-          path="seguimiento-jornadas"
-          element={
-            SeguimientoJornadas ? (
-              <SeguimientoJornadas />
-            ) : (
-              <div>Seguimiento Jornadas (pendiente de módulo)</div>
-            )
-          }
-        />
-
+        <Route path="seguimiento-jornadas" element={<SeguimientoJornadas />} />
         <Route path="*" element={<Navigate to="." replace />} />
       </Routes>
     </AppShell>

--- a/apps/mfe-contratos/src/modules/dashboard-gerencial/pages/DashboardGerencial.tsx
+++ b/apps/mfe-contratos/src/modules/dashboard-gerencial/pages/DashboardGerencial.tsx
@@ -4,6 +4,89 @@ import {
   type DashboardGerencialPayload,
 } from '@nanutech/api-client';
 
+const dashboardGerencialFallback: DashboardGerencialPayload = {
+  ultimo_actualizacion: new Date().toISOString(),
+  estado_sistema: 'Datos referenciales',
+  resumen_general: {
+    jornadas: 22,
+    jornadas_completadas: 18,
+    horas_acumuladas: '164.5',
+    km_totales: 29159,
+    eficiencia: '82%',
+    flota_activa: 12,
+    conductores_activos: 9,
+    contratos_activos: 6,
+    ingresos_estimados: 84500,
+  },
+  graficas: {
+    jornadas_por_dia: [
+      { fecha_jornada: '2026-05-06', total: '4', km: '512' },
+      { fecha_jornada: '2026-05-07', total: '5', km: '690' },
+      { fecha_jornada: '2026-05-08', total: '6', km: '730' },
+      { fecha_jornada: '2026-05-09', total: '3', km: '405' },
+    ],
+    sectores_jornadas: [
+      { estado: 'COMPLETADA', total: '18' },
+      { estado: 'EN_PROCESO', total: '4' },
+    ],
+    sectores_camiones: [
+      { estado: 'DISPONIBLE', total: '8' },
+      { estado: 'EN_RUTA', total: '4' },
+    ],
+    sectores_conductores: [
+      { estado: 'ACTIVO', total: '9' },
+      { estado: 'DESCANSO', total: '3' },
+    ],
+  },
+  operaciones: {
+    en_progreso: [
+      { id: 'op-1', conductor: 'Luis Herrera', camion: 'ABC-123', hora_inicio: '2026-05-10T08:30:00.000Z' },
+      { id: 'op-2', conductor: 'Rosa Mendez', camion: 'DEF-456', hora_inicio: '2026-05-10T09:15:00.000Z' },
+    ],
+    camiones_mantenimiento: [
+      { placa: 'GHI-789', marca: 'Volvo', modelo: 'FH' },
+    ],
+    conductores_disponibles: [
+      { nombre: 'Carlos Ruiz' },
+      { nombre: 'Ana Torres' },
+      { nombre: 'Miguel Castro' },
+    ],
+  },
+  rendimiento: {
+    top_conductores_km: [
+      { conductor: 'Luis Herrera', km_totales: '6420' },
+      { conductor: 'Rosa Mendez', km_totales: '5980' },
+      { conductor: 'Carlos Ruiz', km_totales: '5340' },
+    ],
+    top_camiones_uso: [
+      { placa: 'ABC-123', usos: '14', km_totales: '9200' },
+      { placa: 'DEF-456', usos: '12', km_totales: '8150' },
+    ],
+  },
+  historial: [
+    {
+      id: 'hist-1',
+      conductor: 'Luis Herrera',
+      camion: 'ABC-123',
+      hora_inicio: '2026-05-09T08:00:00.000Z',
+      hora_fin: '2026-05-09T17:00:00.000Z',
+      km_recorridos: '520',
+      horas_duracion: '9',
+      estado: 'COMPLETADA',
+    },
+    {
+      id: 'hist-2',
+      conductor: 'Rosa Mendez',
+      camion: 'DEF-456',
+      hora_inicio: '2026-05-10T09:15:00.000Z',
+      hora_fin: null,
+      km_recorridos: '188',
+      horas_duracion: '3.5',
+      estado: 'EN_PROCESO',
+    },
+  ],
+};
+
 function DashboardGerencial() {
   const [data, setData] = useState<DashboardGerencialPayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -12,12 +95,15 @@ function DashboardGerencial() {
   useEffect(() => {
     getDashboardGerencial({ tiempo: 'todas' })
       .then((res) => setData(res))
-      .catch(() => setError('Error al obtener datos del dashboard gerencial'))
+      .catch(() => {
+        setData(dashboardGerencialFallback);
+        setError('No se pudo conectar con /dashboard/gerencial. Se muestran datos referenciales.');
+      })
       .finally(() => setLoading(false));
   }, []);
 
   if (loading) return <div className="p-8 text-blue-700 animate-pulse">Cargando dashboard gerencial...</div>;
-  if (error || !data) return <div className="p-8 text-red-500">{error}</div>;
+  if (!data) return <div className="p-8 text-red-500">No hay datos disponibles para el dashboard gerencial</div>;
 
   const { resumen_general, graficas, operaciones, rendimiento, historial, estado_sistema } = data;
 
@@ -27,6 +113,12 @@ function DashboardGerencial() {
         <h2 className="text-xl font-bold text-slate-800">Dashboard Gerencial</h2>
         <span className="text-sm text-green-600 font-medium">{estado_sistema}</span>
       </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+          {error}
+        </div>
+      )}
 
       {/* Resumen general */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/apps/mfe-contratos/src/modules/registro-contrato/pages/RegistroContratoPage.tsx
+++ b/apps/mfe-contratos/src/modules/registro-contrato/pages/RegistroContratoPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { crearContrato } from '@nanutech/api-client';
 import {
   ContractSummaryPanel,
   InlineNotice,
@@ -11,14 +12,13 @@ import {
 } from '../components/RegistroFormControls';
 import { Stepper } from '../components/Stepper';
 import { initialRegistroContratoForm, terminalOptions, tipoServicioOptions } from '../constants';
-import { createMockContrato } from '../mocks/registroContratoRepository';
 import type {
   RegistroContratoErrors,
   RegistroContratoForm,
   RegistroContratoPageProps,
   RegistroContratoSuccess,
 } from '../types';
-import { getRegistroTarifaTotal } from '../utils/registroContratoMapper';
+import { buildCrearContratoPayload, getRegistroTarifaTotal } from '../utils/registroContratoMapper';
 import {
   hasErrors,
   validateGeneralStep,
@@ -32,11 +32,7 @@ import {
  * Esta pagina es el entregable principal de la historia:
  * 1. Captura datos generales del cliente y vigencia.
  * 2. Captura parametros de ruta que luego usara monitoreo/GPS.
- * 3. Captura tarifas, calcula tarifa total y genera un ID unico mock.
- *
- * El backend aun no esta listo; por eso la creacion esta aislada en
- * createMockContrato(). Cuando exista el API AWS, se reemplaza ese repositorio
- * sin reescribir el flujo visual ni las validaciones.
+ * 3. Captura tarifas, calcula tarifa total y registra el contrato en el API.
  */
 export default function RegistroContratoPage({ onBack, onRegistered }: RegistroContratoPageProps) {
   // Paso actual del wizard: 1 datos generales, 2 ruta de servicio, 3 reglas de tarifa.
@@ -48,8 +44,9 @@ export default function RegistroContratoPage({ onBack, onRegistered }: RegistroC
   // Errores por campo, poblados por los validadores del modulo.
   const [errors, setErrors] = useState<RegistroContratoErrors>({});
 
-  // Estado de guardado para deshabilitar el boton mientras se crea el mock.
+  // Estado de guardado para deshabilitar el boton mientras responde el backend.
   const [loading, setLoading] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   // Contrato registrado. Si existe, se muestra la pantalla final de exito.
   const [registeredContrato, setRegisteredContrato] = useState<RegistroContratoSuccess | null>(null);
@@ -83,8 +80,8 @@ export default function RegistroContratoPage({ onBack, onRegistered }: RegistroC
   };
 
   /**
-   * Registra el contrato en modo mock.
-   * Genera ID unico, tarifa total y devuelve el contrato a App.tsx mediante onRegistered.
+   * Registra el contrato en backend usando POST /contratos.
+   * Devuelve el contrato creado a App.tsx mediante onRegistered.
    */
   const registrar = async () => {
     const nextErrors = validateRatesStep(form);
@@ -92,14 +89,26 @@ export default function RegistroContratoPage({ onBack, onRegistered }: RegistroC
     if (hasErrors(nextErrors)) return;
 
     setLoading(true);
+    setSubmitError(null);
     try {
-      const contrato = await createMockContrato(form);
+      const contrato = await crearContrato(buildCrearContratoPayload(form));
       setRegisteredContrato({
         id: contrato.id,
         codigo: contrato.codigo,
         estado: contrato.estado,
       });
       onRegistered?.(contrato);
+    } catch (error) {
+      const apiError = error as {
+        response?: { data?: { message?: string; mensaje?: string } };
+        message?: string;
+      };
+      setSubmitError(
+        apiError.response?.data?.message ||
+          apiError.response?.data?.mensaje ||
+          apiError.message ||
+          'No se pudo registrar el contrato en el backend'
+      );
     } finally {
       setLoading(false);
     }
@@ -349,6 +358,12 @@ export default function RegistroContratoPage({ onBack, onRegistered }: RegistroC
           )}
 
           {/* Navegacion del wizard: cancelar, anterior, siguiente y registrar. */}
+          {submitError && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-600">
+              {submitError}
+            </div>
+          )}
+
           <footer className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-3">
               {step > 1 && (
@@ -406,7 +421,7 @@ function SuccessState({
       </div>
       <h2 className="mt-6 text-2xl font-bold text-slate-950">Contrato registrado exitosamente</h2>
       <p className="mx-auto mt-2 max-w-md text-sm text-slate-500">
-        El contrato ha sido creado y esta disponible en el sistema mock para asociar jornadas y registrar kilometrajes.
+        El contrato ha sido creado en el backend y esta disponible para asociar jornadas y registrar kilometrajes.
       </p>
 
       <div className="mx-auto mt-6 inline-flex items-center gap-5 rounded-lg border border-blue-200 bg-blue-50 px-6 py-4">

--- a/apps/mfe-contratos/src/modules/registro-contrato/utils/registroContratoMapper.ts
+++ b/apps/mfe-contratos/src/modules/registro-contrato/utils/registroContratoMapper.ts
@@ -7,7 +7,7 @@ export const toMoneyNumber = (value: string) => Number(Number(value || 0).toFixe
 
 /**
  * Traduce el formulario editable al shape que espera crear contrato.
- * Hoy lo consume el repositorio mock; luego puede enviarse al API sin cambiar la pagina.
+ * Este payload se envia al API de contratos mediante POST /contratos.
  */
 export const buildCrearContratoPayload = (form: RegistroContratoForm) => ({
   cliente: form.cliente.trim(),

--- a/apps/mfe-contratos/vite.config.ts
+++ b/apps/mfe-contratos/vite.config.ts
@@ -16,6 +16,19 @@ export default defineConfig({
       shared: ["react", "react-dom", "react-router-dom"],
     }),
   ],
+  server: {
+    port: 4174,
+  },
+  preview: {
+    port: 4174,
+  },
+  build: {
+    modulePreload: false,
+    target: "esnext",
+    minify: false,
+    cssCodeSplit: false,
+  },
+
   //test
   test: {
     globals: true,

--- a/apps/mfe-dashboard/src/App.test.tsx
+++ b/apps/mfe-dashboard/src/App.test.tsx
@@ -1,38 +1,49 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { AppRoutes } from "./App";
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";
 
 describe("Dashboard Microfrontend", () => {
   beforeEach(() => {
-    //Creamos un "doble de acción" (Mock) para la función fetch del navegador
+    // Mock de fetch para que las pantallas no llamen servicios reales durante la prueba.
     globalThis.fetch = vi.fn(() =>
       Promise.resolve({
         ok: true,
         json: () =>
           Promise.resolve({
             data: [
-              { id: 1, nombre: "Camión 1", estado: "disponible" },
-              { id: 2, nombre: "Camión 2", estado: "disponible" },
+              { id: 1, nombre: "Camion 1", estado: "disponible" },
+              { id: 2, nombre: "Camion 2", estado: "disponible" },
             ],
           }),
       }),
     ) as unknown as typeof fetch;
   });
 
-  it("debería renderizar el título principal correctamente", async () => {
-    //Renderizamos el componente
+  it("renderiza el titulo principal cuando se abre el MFE directo", async () => {
     render(
       <MemoryRouter>
         <AppRoutes />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
-    //Esperamos a que el título se renderice
     await waitFor(() => {
-      const titulo = screen.getByText("Dashboard Ejecutivo");
-      expect(titulo).toBeInTheDocument();
+      expect(screen.getByText("Dashboard Ejecutivo")).toBeInTheDocument();
+    });
+  });
+
+  it("renderiza el dashboard admin cuando el shell lo monta en /dashboard/admin/*", async () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard/admin/dashboard"]}>
+        <Routes>
+          <Route path="/dashboard/admin/*" element={<AppRoutes />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Dashboard Ejecutivo")).toBeInTheDocument();
     });
   });
 });

--- a/apps/mfe-dashboard/src/App.tsx
+++ b/apps/mfe-dashboard/src/App.tsx
@@ -1,43 +1,42 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import Dashboard from "./modules/dashboard-admin/pages/Dashboard";
 import RegistroJornada from "./modules/registro-jornada/pages/RegistroJornada";
 import RegistroNuevaJornada from "./modules/registro-jornada/pages/RegistroNuevaJornada";
 import MonitoreoCamionesPage from "./modules/monitoreo-camiones";
-
-// GPS
 import GpsIntegrationPage from "./modules/gps-integration/pages/GpsIntegrationPage";
 
 export function AppRoutes() {
   return (
     <Routes>
-      {/* 🔥 ENTRADA DIRECTA AL DASHBOARD */}
-      <Route path="/" element={<Navigate to="/dashboard/admin" replace />} />
+      {/* Rutas relativas usadas cuando el shell monta este MFE en /dashboard/admin/*. */}
+      <Route index element={<Navigate to="dashboard" replace />} />
+      <Route path="dashboard" element={<Dashboard />} />
+      <Route path="gps" element={<GpsIntegrationPage />} />
+      <Route path="registro-jornada" element={<RegistroJornada />} />
+      <Route path="registro-jornada/nueva" element={<RegistroNuevaJornada />} />
+      <Route path="camiones" element={<MonitoreoCamionesPage />} />
 
-      {/* DASHBOARD ADMIN */}
-      <Route path="/dashboard/admin" element={<Dashboard />} />
+      {/* Compatibilidad cuando el MFE se abre directo en localhost:3001. */}
+      <Route path="/" element={<Navigate to="/dashboard/admin/dashboard" replace />} />
+      <Route path="/dashboard/admin" element={<Navigate to="/dashboard/admin/dashboard" replace />} />
+      <Route path="/dashboard/admin/dashboard" element={<Dashboard />} />
+      <Route path="/dashboard/admin/gps" element={<GpsIntegrationPage />} />
+      <Route path="/dashboard/admin/registro-jornada" element={<RegistroJornada />} />
+      <Route path="/dashboard/admin/registro-jornada/nueva" element={<RegistroNuevaJornada />} />
+      <Route path="/dashboard/admin/camiones" element={<MonitoreoCamionesPage />} />
+      <Route path="/gps" element={<Navigate to="/dashboard/admin/gps" replace />} />
+      <Route path="/RegistroJornada" element={<Navigate to="/dashboard/admin/registro-jornada" replace />} />
+      <Route path="/RegistroNuevaJornada" element={<Navigate to="/dashboard/admin/registro-jornada/nueva" replace />} />
+      <Route path="/camiones" element={<Navigate to="/dashboard/admin/camiones" replace />} />
 
-      {/* GPS */}
-      <Route path="/gps" element={<GpsIntegrationPage />} />
-
-      {/* JORNADAS */}
-      <Route path="/RegistroJornada" element={<RegistroJornada />} />
-      <Route path="/RegistroNuevaJornada" element={<RegistroNuevaJornada />} />
-
-      {/* MONITOREO DE CAMIONES */}
-      <Route path="/camiones" element={<MonitoreoCamionesPage />} />
-
-      {/* 🔥 CUALQUIER RUTA INVALIDA TAMBIÉN VA AL DASHBOARD */}
-      <Route path="*" element={<Navigate to="/dashboard/admin" replace />} />
+      {/* Cualquier ruta invalida vuelve al panel principal sin salir del contexto actual. */}
+      <Route path="*" element={<Navigate to="dashboard" replace />} />
     </Routes>
   );
 }
 
 function App() {
-  return (
-    <BrowserRouter>
-      <AppRoutes />
-    </BrowserRouter>
-  );
+  return <AppRoutes />;
 }
 
 export default App;

--- a/apps/shell-app/__tests__/unit/auth/LoginPage.test.tsx
+++ b/apps/shell-app/__tests__/unit/auth/LoginPage.test.tsx
@@ -23,8 +23,8 @@ const renderLogin = () =>
     >
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/dashboard/admin" element={<div>Dashboard admin</div>} />
-        <Route path="/dashboard/contratos" element={<div>Dashboard gerente</div>} />
+        <Route path="/dashboard/admin/dashboard" element={<div>Dashboard admin</div>} />
+        <Route path="/dashboard/contratos/dashboard" element={<div>Dashboard gerente</div>} />
         <Route path="/dashboard/chofer" element={<div>Dashboard chofer</div>} />
       </Routes>
     </MemoryRouter>
@@ -109,6 +109,29 @@ describe('LoginPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Iniciar/i }));
 
     expect(await screen.findByText('Dashboard admin')).not.toBeNull();
+  });
+
+  it('ignora un nextRoute de otro rol y mantiene al gerente en contratos', async () => {
+    // Protege el flujo si el backend envia una ruta antigua o de otro perfil.
+    vi.mocked(login).mockResolvedValue({
+      data: {
+        user: { id: 'gerente-2', email: 'gerente@nanutech.com' },
+        role: 'GERENTE',
+        nextRoute: '/dashboard/admin/dashboard',
+        session: {
+          accessToken: 'access-token',
+          idToken: 'id-token',
+          expiresAt: '2026-05-09T23:59:00.000Z',
+        },
+      },
+    } as never);
+
+    renderLogin();
+
+    completarFormulario('gerente@nanutech.com', 'Gerente123!');
+    fireEvent.click(screen.getByRole('button', { name: /Iniciar/i }));
+
+    expect(await screen.findByText('Dashboard gerente')).not.toBeNull();
   });
 
   it('muestra mensaje de error cuando Cognito rechaza credenciales', async () => {

--- a/apps/shell-app/__tests__/unit/components/ProtectedRoute.test.tsx
+++ b/apps/shell-app/__tests__/unit/components/ProtectedRoute.test.tsx
@@ -20,8 +20,8 @@ const renderProtectedRoute = (allowedRoles?: string[]) =>
           }
         />
         <Route path="/login" element={<div>Login destino</div>} />
-        <Route path="/dashboard/admin" element={<div>Home admin</div>} />
-        <Route path="/dashboard/contratos" element={<div>Home gerente</div>} />
+        <Route path="/dashboard/admin/dashboard" element={<div>Home admin</div>} />
+        <Route path="/dashboard/contratos/dashboard" element={<div>Home gerente</div>} />
         <Route path="/dashboard/chofer" element={<div>Home chofer</div>} />
       </Routes>
     </MemoryRouter>

--- a/apps/shell-app/src/App.tsx
+++ b/apps/shell-app/src/App.tsx
@@ -66,7 +66,7 @@ function App() {
       <Route
         path="/dashboard/admin/*"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute allowedRoles={['ADMIN']}>
             <DashboardLayout />
           </ProtectedRoute>
         }
@@ -74,17 +74,13 @@ function App() {
 
       <Route
         path="/dashboard/gerencial"
-        element={
-          <ProtectedRoute>
-            <DashboardLayout />
-          </ProtectedRoute>
-        }
+        element={<Navigate to="/dashboard/contratos/dashboard" replace />}
       />
 
       <Route
         path="/dashboard/chofer/*"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute allowedRoles={['CHOFER', 'CONDUCTOR']}>
             <ChoferLayout />
           </ProtectedRoute>
         }
@@ -93,7 +89,7 @@ function App() {
       <Route
         path="/dashboard/contratos/*"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute allowedRoles={['GERENTE', 'GERENCIAL']}>
             <ContratosLayout />
           </ProtectedRoute>
         }

--- a/apps/shell-app/src/components/ProtectedRoute.tsx
+++ b/apps/shell-app/src/components/ProtectedRoute.tsx
@@ -16,9 +16,10 @@ const clearSession = () => {
 const getHomeRouteByRole = (role: string | null) => {
   switch ((role || '').toUpperCase()) {
     case 'ADMIN':
-      return '/dashboard/admin';
+      return '/dashboard/admin/dashboard';
     case 'GERENTE':
-      return '/dashboard/contratos';
+    case 'GERENCIAL':
+      return '/dashboard/contratos/dashboard';
     default:
       return '/dashboard/chofer';
   }

--- a/apps/shell-app/src/pages/Auth/LoginPage.tsx
+++ b/apps/shell-app/src/pages/Auth/LoginPage.tsx
@@ -3,6 +3,34 @@ import { useNavigate } from 'react-router-dom';
 import { login } from '@nanutech/api-client';
 import { validarFormatoCorreo } from '@nanutech/utils';
 
+const getDashboardRouteByRole = (role: string) => {
+  switch (role.toUpperCase()) {
+    case 'ADMIN':
+      return '/dashboard/admin/dashboard';
+    case 'GERENTE':
+    case 'GERENCIAL':
+      return '/dashboard/contratos/dashboard';
+    default:
+      return '/dashboard/chofer';
+  }
+};
+
+const normalizeNextRoute = (role: string, nextRoute?: string) => {
+  if (!nextRoute) {
+    return getDashboardRouteByRole(role);
+  }
+
+  if (role.toUpperCase() === 'ADMIN' && nextRoute.startsWith('/dashboard/admin')) {
+    return nextRoute === '/dashboard/admin' ? '/dashboard/admin/dashboard' : nextRoute;
+  }
+
+  if (['GERENTE', 'GERENCIAL'].includes(role.toUpperCase()) && nextRoute.startsWith('/dashboard/contratos')) {
+    return nextRoute === '/dashboard/contratos' ? '/dashboard/contratos/dashboard' : nextRoute;
+  }
+
+  return getDashboardRouteByRole(role);
+};
+
 export default function LoginPage() {
   const [correo, setCorreo] = useState('');
   const [password, setPassword] = useState('');
@@ -35,20 +63,8 @@ export default function LoginPage() {
       localStorage.setItem('nanutech_user', JSON.stringify(user));
       localStorage.setItem('nanutech_role', role);
       localStorage.setItem('nanutech_expires_at', session.expiresAt);
-      localStorage.setItem('nanutech_token', respuesta.data.session.accessToken);
-      localStorage.setItem('nanutech_user', JSON.stringify(respuesta.data.user));
 
-      if (nextRoute) {
-        navigate(nextRoute);
-      } else if (role.toUpperCase() === 'ADMIN') {
-        navigate('/dashboard/admin');
-      } else if (role.toUpperCase() === 'GERENCIAL') {
-        navigate('/dashboard/gerencial');
-      } else if (role.toUpperCase() === 'GERENTE') {
-        navigate('/dashboard/contratos');
-      } else {
-        navigate('/dashboard/chofer');
-      }
+      navigate(normalizeNextRoute(role, nextRoute));
     } catch (err: unknown) {
       const error = err as {
         response?: { data?: { message?: string; mensaje?: string } };


### PR DESCRIPTION
## Resumen

- Corrige la navegación por rol desde el login:
  - ADMIN -> mfe-dashboard
  - GERENTE/GERENCIAL -> mfe-contratos
- Ajusta las rutas internas del dashboard admin para que cargue correctamente desde el shell.
- Corrige el dashboard gerencial:
  - evita doble opción activa en el menú lateral
  - agrega menú de sesión y cierre de sesión
  - muestra datos referenciales si falla el endpoint `/dashboard/gerencial`
- Cambia el registro de contratos de mock a backend real usando `POST /contratos`.
- Agrega y actualiza pruebas unitarias para cubrir los flujos corregidos.

## Validaciones

- `npm run type-check`
- `npm run test:coverage -w apps/shell-app`
- `npm run test:coverage -w apps/mfe-dashboard`
- `npm run test:coverage -w apps/mfe-contratos`
- `npm run build -w apps/mfe-dashboard`
- `npm run build -w apps/mfe-contratos`

## Notas

Para probar en local desde el shell, los remotos deben estar compilados y levantados en preview para consumir el `remoteEntry.js`.
