### PR TITLE
HU11 - Panel de Monitoreo y Gestión de Camiones

### DIFF
--- a/apps/mfe-dashboard/__tests__/unit/hu11-monitoreo-camiones/MonitoreoCamionesPage.test.tsx
+++ b/apps/mfe-dashboard/__tests__/unit/hu11-monitoreo-camiones/MonitoreoCamionesPage.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { crearCamionHu11, getPanelCamionesHu11 } from "@nanutech/api-client";
+import { crearCamionHu11, descargarCamionesHu11Csv, getPanelCamionesHu11 } from "@nanutech/api-client";
 import type { CamionHu11, PanelCamionesHu11 } from "@nanutech/api-client";
 import MonitoreoCamionesPage from "../../../src/modules/monitoreo-camiones";
 
@@ -10,12 +10,11 @@ import MonitoreoCamionesPage from "../../../src/modules/monitoreo-camiones";
 // Por eso reemplazamos sus componentes por versiones simples y estables para pruebas unitarias.
 vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  BarChart: ({ children }: { children: ReactNode }) => <div data-testid="bar-chart">{children}</div>,
-  Bar: () => <div />,
-  CartesianGrid: () => <div />,
+  PieChart: ({ children }: { children: ReactNode }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Cell: () => <div />,
+  Legend: () => <div />,
   Tooltip: () => <div />,
-  XAxis: () => <div />,
-  YAxis: () => <div />,
 }));
 
 // Mock del cliente API: permite controlar respuestas sin depender del backend real.
@@ -107,11 +106,11 @@ describe("HU11 - Monitoreo de camiones", () => {
     expect(await screen.findByText("Total Camiones")).toBeInTheDocument();
     // getAllByText se usa porque "En Uso" puede aparecer en menú, KPI o tarjeta.
     expect(screen.getAllByText("En Uso").length).toBeGreaterThan(0);
-    expect(screen.getByText("Disponibles")).toBeInTheDocument();
+    expect(screen.getAllByText("Disponibles").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Mantenimiento").length).toBeGreaterThan(0);
-    expect(screen.getByText("Comparativa de Horas: Movimiento vs Detenido")).toBeInTheDocument();
+    expect(screen.getByText("Comparativas de Horas: Movimiento vs Detenido")).toBeInTheDocument();
     // Valida que el gráfico mockeado se haya renderizado.
-    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("pie-chart")).toBeInTheDocument();
   });
 
   // Comprueba que búsqueda y filtro de estado modifiquen la grilla visible.
@@ -124,7 +123,7 @@ describe("HU11 - Monitoreo de camiones", () => {
     expect(screen.getByText("DEF-456")).toBeInTheDocument();
 
     // Escribe una placa parcial para filtrar por búsqueda.
-    fireEvent.change(screen.getByPlaceholderText("Buscar por placa o marca..."), {
+    fireEvent.change(screen.getByPlaceholderText("Buscar por placa..."), {
       target: { value: "ABC" },
     });
 
@@ -183,10 +182,11 @@ describe("HU11 - Monitoreo de camiones", () => {
     // within evita que las búsquedas tomen elementos fuera del modal.
     const form = within(modal as HTMLFormElement);
     // Completa campos requeridos por las validaciones del componente.
+    fireEvent.change(form.getByLabelText("ID *"), { target: { value: "unidad-003" } });
     fireEvent.change(form.getByLabelText("Placa *"), { target: { value: "GHI-789" } });
     fireEvent.change(form.getByLabelText("Marca *"), { target: { value: "Mercedes-Benz" } });
     fireEvent.change(form.getByLabelText("Modelo *"), { target: { value: "Actros" } });
-    fireEvent.change(form.getByLabelText("Capacidad (toneladas) *"), { target: { value: "26" } });
+    fireEvent.change(form.getByLabelText("Capacidad (ton) *"), { target: { value: "26" } });
     fireEvent.change(form.getByLabelText("VIN *"), { target: { value: "VINGHI789" } });
     fireEvent.change(form.getByLabelText("Color *"), { target: { value: "Azul" } });
     // Envía el formulario desde el botón submit.
@@ -199,5 +199,28 @@ describe("HU11 - Monitoreo de camiones", () => {
 
     // Verifica que el toast muestre los datos del nuevo camión.
     expect(screen.getByText("GHI-789 · Actros fue agregado al sistema.")).toBeInTheDocument();
+  });
+
+  // Comprueba que la descarga de CSV use los filtros aplicados en pantalla.
+  it("descarga CSV respetando busqueda por placa y estado", async () => {
+    vi.mocked(descargarCamionesHu11Csv).mockResolvedValue('"ID","Placa"\n"unidad-001","ABC-123"');
+
+    renderPage();
+    await screen.findByText("ABC-123");
+
+    fireEvent.change(screen.getByPlaceholderText("Buscar por placa..."), {
+      target: { value: "ABC" },
+    });
+    fireEvent.change(screen.getByLabelText("Estado"), {
+      target: { value: "EN_JORNADA" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Descargar CSV/i }));
+
+    await waitFor(() => {
+      expect(descargarCamionesHu11Csv).toHaveBeenCalledWith({
+        placa: "ABC",
+        estado: "EN_JORNADA",
+      });
+    });
   });
 });

--- a/apps/mfe-dashboard/src/modules/monitoreo-camiones/MonitoreoCamionesPage.tsx
+++ b/apps/mfe-dashboard/src/modules/monitoreo-camiones/MonitoreoCamionesPage.tsx
@@ -97,11 +97,11 @@ function MonitoreoCamionesPage() {
     const normalizedSearch = search.trim().toUpperCase();
 
     return panel.camiones.filter((camion) => {
-      const matchesSearch =
-        !normalizedSearch ||
-        camion.placa.toUpperCase().includes(normalizedSearch) ||
-        camion.marca.toUpperCase().includes(normalizedSearch);
-      const matchesEstado = estado === "TODOS" || camion.estado === estado;
+      const matchesSearch = !normalizedSearch || camion.placa.toUpperCase().includes(normalizedSearch);
+      const matchesEstado =
+        estado === "TODOS" ||
+        camion.estado === estado ||
+        (estado === "EN_JORNADA" && camion.estado === "EN_AUXILIO");
 
       return matchesSearch && matchesEstado;
     });
@@ -109,13 +109,6 @@ function MonitoreoCamionesPage() {
 
   // Recalcula KPIs y porcentajes usando solo los camiones filtrados.
   const filteredPanel = useMemo(() => crearPanelDesdeCamiones(filteredCamiones), [filteredCamiones]);
-
-  // Adapta la lista filtrada al formato esperado por Recharts.
-  const chartData = filteredCamiones.map((camion) => ({
-    placa: camion.placa,
-    movimiento: camion.horas_movimiento,
-    detenido: camion.horas_detenido,
-  }));
 
   // Actualiza un campo específico del formulario sin perder los demás.
   const handleFormChange = (field: keyof FormState, value: string | boolean) => {
@@ -128,7 +121,7 @@ function MonitoreoCamionesPage() {
     setFormError("");
 
     const payload: CrearCamionHu11Payload = {
-      id: form.id.trim() || undefined,
+      id: form.id.trim(),
       placa: form.placa.trim().toUpperCase(),
       marca: form.marca.trim(),
       modelo: form.modelo.trim(),
@@ -143,7 +136,7 @@ function MonitoreoCamionesPage() {
       notas: form.notas.trim() || undefined,
     };
 
-    if (!payload.placa || !payload.marca || !payload.modelo || !payload.vin || !payload.color) {
+    if (!payload.id || !payload.placa || !payload.marca || !payload.modelo || !payload.vin || !payload.color) {
       setFormError("Completa los campos obligatorios antes de registrar.");
       return;
     }
@@ -231,8 +224,8 @@ function MonitoreoCamionesPage() {
             <>
               <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
                 <KpiCard label="Total Camiones" value={panel.resumen.total_camiones} tone="blue" icon="truck" />
-                <KpiCard label="En Uso" value={panel.resumen.en_uso} tone="green" icon="route" />
-                <KpiCard label="Disponibles" value={panel.resumen.disponibles} tone="blue" icon="pin" />
+                <KpiCard label="En Uso" value={panel.resumen.en_uso} tone="blue" icon="route" />
+                <KpiCard label="Disponibles" value={panel.resumen.disponibles} tone="green" icon="pin" />
                 <KpiCard label="Mantenimiento" value={panel.resumen.mantenimiento} tone="orange" icon="alert" />
               </section>
 
@@ -244,7 +237,7 @@ function MonitoreoCamionesPage() {
                 onOpenRegister={() => setModalOpen(true)}
                 onDownloadCsv={handleDownloadCsv}
               />
-              <MovementChart chartData={chartData} filteredPanel={filteredPanel} />
+              <MovementChart filteredPanel={filteredPanel} />
               <FleetGrid
                 camiones={filteredCamiones}
                 totalCamiones={panel.camiones.length}

--- a/apps/mfe-dashboard/src/modules/monitoreo-camiones/components/FleetFilters.tsx
+++ b/apps/mfe-dashboard/src/modules/monitoreo-camiones/components/FleetFilters.tsx
@@ -40,7 +40,7 @@ export function FleetFilters({
             className="inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-50"
           >
             <span aria-hidden="true">↓</span>
-            Exportar CSV
+            Descargar CSV
           </button>
         </div>
       </div>
@@ -49,7 +49,7 @@ export function FleetFilters({
         <input
           value={search}
           onChange={(event) => onSearchChange(event.target.value)}
-          placeholder="Buscar por placa o marca..."
+          placeholder="Buscar por placa..."
           className="h-9 rounded-md border border-gray-200 bg-gray-50 px-3 text-sm outline-none focus:border-blue-500 focus:bg-white"
         />
         <select

--- a/apps/mfe-dashboard/src/modules/monitoreo-camiones/components/MovementChart.tsx
+++ b/apps/mfe-dashboard/src/modules/monitoreo-camiones/components/MovementChart.tsx
@@ -1,46 +1,89 @@
 import type { PanelCamionesHu11 } from "@nanutech/api-client";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import type { ReactNode } from "react";
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import type { PieLabelRenderProps } from "recharts";
 
 type MovementChartProps = {
-  chartData: Array<{
-    placa: string;
-    movimiento: number;
-    detenido: number;
-  }>;
   filteredPanel: PanelCamionesHu11;
 };
 
-// Gráfico de movimiento frente a tiempo detenido por camión.
-export function MovementChart({ chartData, filteredPanel }: MovementChartProps) {
+const chartColors = {
+  movimiento: "#2563eb",
+  detenido: "#f59e0b",
+};
+
+type MovementChartItem = {
+  name: string;
+  value: number;
+  percentage: number;
+  color: string;
+};
+
+const renderPieLabel = ({ name, payload }: PieLabelRenderProps): ReactNode => {
+  const item = payload as MovementChartItem | undefined;
+  return `${name}: ${item?.percentage ?? 0}%`;
+};
+
+// Grafico circular de movimiento frente a tiempo detenido para la flota filtrada.
+export function MovementChart({ filteredPanel }: MovementChartProps) {
+  const totalHours =
+    filteredPanel.grafica_movimiento.horas_movimiento + filteredPanel.grafica_movimiento.horas_detenido;
+
+  const chartData: MovementChartItem[] = [
+    {
+      name: "Movimiento",
+      value: filteredPanel.grafica_movimiento.horas_movimiento,
+      percentage: filteredPanel.grafica_movimiento.porcentaje_movimiento,
+      color: chartColors.movimiento,
+    },
+    {
+      name: "Detenido",
+      value: filteredPanel.grafica_movimiento.horas_detenido,
+      percentage: filteredPanel.grafica_movimiento.porcentaje_detenido,
+      color: chartColors.detenido,
+    },
+  ];
+
   return (
     <section className="mt-4 rounded-lg border border-gray-200 bg-white p-5">
-      <h2 className="text-sm font-bold text-gray-900">Comparativa de Horas: Movimiento vs Detenido</h2>
-      <p className="mb-4 text-xs text-gray-500">Análisis de tiempo de operación por camión</p>
-      <div className="h-72">
+      <h2 className="text-sm font-bold text-gray-900">Comparativas de Horas: Movimiento vs Detenido</h2>
+      <p className="mb-4 text-xs text-gray-500">Porcentaje de tiempo operativo frente a tiempo detenido</p>
+      <div className="relative h-72">
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={chartData}>
-            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
-            <XAxis dataKey="placa" tick={{ fontSize: 11 }} />
-            <YAxis tick={{ fontSize: 11 }} />
-            <Tooltip />
-            <Bar dataKey="movimiento" fill="#10b981" radius={[4, 4, 0, 0]} name="Movimiento" />
-            <Bar dataKey="detenido" fill="#f59e0b" radius={[4, 4, 0, 0]} name="Detenido" />
-          </BarChart>
+          <PieChart>
+            <Pie
+              data={chartData}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              innerRadius={58}
+              outerRadius={92}
+              paddingAngle={3}
+              label={renderPieLabel}
+              labelLine={false}
+            >
+              {chartData.map((entry) => (
+                <Cell key={entry.name} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip formatter={(value, name) => [`${Number(value ?? 0)} h`, String(name)]} />
+            <Legend verticalAlign="bottom" iconType="square" />
+          </PieChart>
         </ResponsiveContainer>
+        <div className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[58%] text-center">
+          <p className="text-xs font-semibold uppercase text-gray-400">Total</p>
+          <p className="text-lg font-bold text-gray-900">{totalHours.toFixed(1)} h</p>
+        </div>
       </div>
-      <p className="mt-2 text-right text-xs text-gray-500">
-        Movimiento {filteredPanel.grafica_movimiento.porcentaje_movimiento}% · Detenido{" "}
-        {filteredPanel.grafica_movimiento.porcentaje_detenido}%
-      </p>
+      <div className="mt-2 flex flex-wrap justify-end gap-3 text-xs text-gray-500">
+        {chartData.map((item) => (
+          <span key={item.name} className="inline-flex items-center gap-1.5">
+            <span className="h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: item.color }} />
+            {item.name} {item.percentage}% ({item.value.toFixed(1)} h)
+          </span>
+        ))}
+      </div>
     </section>
   );
 }
-

--- a/apps/mfe-dashboard/src/modules/monitoreo-camiones/components/RegistrationModal.tsx
+++ b/apps/mfe-dashboard/src/modules/monitoreo-camiones/components/RegistrationModal.tsx
@@ -33,12 +33,12 @@ export function RegistrationModal({ form, error, onChange, onClose, onSubmit }: 
 
         <h3 className="mb-3 text-sm font-bold text-gray-900">Información Básica</h3>
         <div className="grid grid-cols-2 gap-3">
-          <FormInput label="ID" value={form.id} onChange={(value) => onChange("id", value)} placeholder="unidad-001" />
+          <FormInput label="ID *" value={form.id} onChange={(value) => onChange("id", value)} placeholder="unidad-001" />
           <FormInput label="Placa *" value={form.placa} onChange={(value) => onChange("placa", value)} placeholder="ABC-123" />
           <FormInput label="Marca *" value={form.marca} onChange={(value) => onChange("marca", value)} placeholder="Volvo, Scania..." />
           <FormInput label="Modelo *" value={form.modelo} onChange={(value) => onChange("modelo", value)} placeholder="FH16, R450..." />
           <FormInput label="Año *" type="number" value={form.anio} onChange={(value) => onChange("anio", value)} />
-          <FormInput label="Capacidad (toneladas) *" type="number" value={form.capacidad_ton} onChange={(value) => onChange("capacidad_ton", value)} placeholder="28" />
+          <FormInput label="Capacidad (ton) *" type="number" value={form.capacidad_ton} onChange={(value) => onChange("capacidad_ton", value)} placeholder="28" />
           <FormInput label="VIN *" value={form.vin} onChange={(value) => onChange("vin", value)} placeholder="VIN único" />
           <FormInput label="Color *" value={form.color} onChange={(value) => onChange("color", value)} placeholder="Blanco, Rojo..." />
         </div>
@@ -46,7 +46,7 @@ export function RegistrationModal({ form, error, onChange, onClose, onSubmit }: 
         <h3 className="mb-3 mt-5 text-sm font-bold text-gray-900">Información Técnica</h3>
         <div className="grid grid-cols-2 gap-3">
           <label className="flex flex-col gap-1 text-xs font-semibold text-gray-700">
-            Tipo de Combustible
+            Combustible
             <select
               value={form.combustible}
               onChange={(event) => onChange("combustible", event.target.value)}

--- a/apps/mfe-dashboard/src/modules/monitoreo-camiones/constants.ts
+++ b/apps/mfe-dashboard/src/modules/monitoreo-camiones/constants.ts
@@ -1,10 +1,9 @@
 // Opciones del selector de estado para filtrar la flota.
 export const estadoOptions = [
-  { label: "Todos los estados", value: "TODOS" },
+  { label: "Todos", value: "TODOS" },
+  { label: "Disponibles", value: "DISPONIBLE" },
   { label: "En Uso", value: "EN_JORNADA" },
-  { label: "Disponible", value: "DISPONIBLE" },
   { label: "Mantenimiento", value: "MANTENIMIENTO" },
-  { label: "Inactivo", value: "INACTIVA" },
 ];
 
 // Traduce estados técnicos del backend a texto legible para el usuario.

--- a/apps/mfe-dashboard/src/modules/monitoreo-camiones/utils/panel.ts
+++ b/apps/mfe-dashboard/src/modules/monitoreo-camiones/utils/panel.ts
@@ -13,7 +13,7 @@ export const crearPanelDesdeCamiones = (camiones: CamionHu11[]): PanelCamionesHu
   return {
     resumen: {
       total_camiones: camiones.length,
-      en_uso: camiones.filter((camion) => camion.estado === "EN_JORNADA").length,
+      en_uso: camiones.filter((camion) => camion.estado === "EN_JORNADA" || camion.estado === "EN_AUXILIO").length,
       disponibles: camiones.filter((camion) => camion.estado === "DISPONIBLE").length,
       mantenimiento: camiones.filter((camion) => camion.estado === "MANTENIMIENTO").length,
     },


### PR DESCRIPTION
## Descripción

Se implementa y ajusta la HU11 - Panel de Monitoreo y Gestión de Camiones en `mfe-dashboard`.

## Cambios realizados

- Se muestran KPIs de Total Camiones, En Uso, Disponibles y Mantenimiento con colores según la HU.
- Se ajustan filtros por placa y estado: Todos, Disponibles, En Uso y Mantenimiento.
- Se agrega gráfica circular con Recharts para comparar horas en Movimiento vs Detenido.
- Se muestra grid responsivo de tarjetas de camiones con placa, modelo, capacidad, horas y kilómetros.
- Se completa el flujo de registro de camión con campos requeridos: ID, Placa, Marca, Modelo, Año, Capacidad, VIN, Color, Combustible y GPS.
- Se valida placa duplicada y campos obligatorios antes de registrar.
- Se agrega confirmación visual al registrar correctamente.
- Se ajusta descarga CSV para respetar filtros aplicados.
- Se actualizan pruebas unitarias de HU11.

## Validación

- `npm run test -w apps/mfe-dashboard`
- `npm run build`

Ambos comandos ejecutados correctamente.
