### PR TITLE
HU10 - Panel de Gestión de Conductores

### DIFF
--- a/apps/mfe-dashboard/__tests__/unit/hu10-gestión-conductores/GestionConductoresPage.test.tsx
+++ b/apps/mfe-dashboard/__tests__/unit/hu10-gestión-conductores/GestionConductoresPage.test.tsx
@@ -42,56 +42,62 @@ vi.mock("@nanutech/api-client", () => ({
   getDashboardConductores: vi.fn(),
 }));
 
+const conductoresBackend = [
+  {
+    id: "conductor-1",
+    nombre: "Carlos Ramirez",
+    licencia: "A-IIIB-12345678",
+    estadoOperacional: "DISPONIBLE",
+    camionAsignado: "Sin asignar",
+    estado: "ACTIVO",
+  },
+  {
+    id: "conductor-2",
+    nombre: "Lucia Torres",
+    licencia: "A-IIIA-87654321",
+    estadoOperacional: "EN_RUTA",
+    camionAsignado: "ABC-123",
+    estado: "ACTIVO",
+  },
+  {
+    id: "conductor-3",
+    nombre: "Mario Salas",
+    licencia: "A-IIC-45678901",
+    estadoOperacional: "DESCANSANDO",
+    camionAsignado: "Sin asignar",
+    estado: "ACTIVO",
+  },
+  {
+    id: "conductor-4",
+    nombre: "Rosa Vega",
+    licencia: "A-IIIB-56781234",
+    estadoOperacional: "SIN_ASIGNAR",
+    camionAsignado: "Sin asignar",
+    estado: "INACTIVO",
+  },
+];
+
 const backendPayload = {
+  indicadores: {
+    total_conductores: 4,
+    conductores_activos: 3,
+    disponibles: 1,
+    en_ruta: 1,
+  },
+  graficos: {
+    distribucionContrato: [
+      { estado: "ACTIVOS", cantidad: 3 },
+      { estado: "INACTIVOS", cantidad: 1 },
+    ],
+    estadoOperacional: [
+      { estado: "DISPONIBLE", cantidad: 1 },
+      { estado: "EN_RUTA", cantidad: 1 },
+      { estado: "DESCANSANDO", cantidad: 1 },
+      { estado: "DE_PERMISO", cantidad: 0 },
+    ],
+  },
   conductores: [
-    {
-      id: "conductor-1",
-      nombre: "Carlos Ramirez",
-      email: "carlos@nanutech.com",
-      dni: "12345678",
-      licencia: "A-IIIB-12345678",
-      contacto: "+51 900111222",
-      estadoContrato: "ACTIVO",
-      estadoOperacional: "DISPONIBLE",
-      camionAsignado: null,
-      activo: true,
-    },
-    {
-      id: "conductor-2",
-      nombre: "Lucia Torres",
-      email: "lucia@nanutech.com",
-      dni: "87654321",
-      licencia: "A-IIIA-87654321",
-      contacto: "+51 900333444",
-      estadoContrato: "ACTIVO",
-      estadoOperacional: "EN_RUTA",
-      camionAsignado: "ABC-123",
-      activo: true,
-    },
-    {
-      id: "conductor-3",
-      nombre: "Mario Salas",
-      email: "mario@nanutech.com",
-      dni: "45678901",
-      licencia: "A-IIC-45678901",
-      contacto: "+51 900555666",
-      estadoContrato: "ACTIVO",
-      estadoOperacional: "DESCANSANDO",
-      camionAsignado: null,
-      activo: true,
-    },
-    {
-      id: "conductor-4",
-      nombre: "Rosa Vega",
-      email: "rosa@nanutech.com",
-      dni: "56781234",
-      licencia: "A-IIIB-56781234",
-      contacto: "+51 900777888",
-      estadoContrato: "INACTIVO",
-      estadoOperacional: "SIN_ASIGNAR",
-      camionAsignado: null,
-      activo: false,
-    },
+    ...conductoresBackend,
   ],
 };
 
@@ -112,7 +118,37 @@ function renderPage(initialEntry = "/dashboard/admin/conductores") {
 describe("HU10 - Gestion de conductores", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getDashboardConductores).mockResolvedValue(backendPayload);
+    vi.mocked(getDashboardConductores).mockImplementation(async (filters = {}) => {
+      let conductores = [...conductoresBackend];
+
+      if (filters.busqueda) {
+        const search = filters.busqueda.toLowerCase();
+        conductores = conductores.filter(
+          (conductor) =>
+            conductor.nombre.toLowerCase().includes(search) ||
+            conductor.licencia.toLowerCase().includes(search),
+        );
+      }
+
+      if (filters.estado && filters.estado !== "TODOS") {
+        conductores = conductores.filter((conductor) =>
+          filters.estado === "ACTIVOS"
+            ? conductor.estado === "ACTIVO"
+            : conductor.estado === "INACTIVO",
+        );
+      }
+
+      if (filters.disponibilidad && filters.disponibilidad !== "TODOS") {
+        conductores = conductores.filter(
+          (conductor) => conductor.estadoOperacional === filters.disponibilidad,
+        );
+      }
+
+      return {
+        ...backendPayload,
+        conductores,
+      };
+    });
   });
 
   it("muestra KPIs, graficas y listado de conductores al cargar", async () => {
@@ -134,25 +170,31 @@ describe("HU10 - Gestion de conductores", () => {
 
     expect(await screen.findByText("Carlos Ramirez")).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText("Buscar por nombre, DNI o licencia..."), {
-      target: { value: "87654321" },
+      target: { value: "Lucia" },
     });
 
-    expect(screen.getByText("Lucia Torres")).toBeInTheDocument();
-    expect(screen.queryByText("Carlos Ramirez")).not.toBeInTheDocument();
+    expect(await screen.findByText("Lucia Torres")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Carlos Ramirez")).not.toBeInTheDocument();
+    });
 
     fireEvent.change(screen.getByPlaceholderText("Buscar por nombre, DNI o licencia..."), {
       target: { value: "" },
     });
     fireEvent.click(screen.getByRole("button", { name: /Inactivos/i }));
 
-    expect(screen.getByText("Rosa Vega")).toBeInTheDocument();
-    expect(screen.queryByText("Lucia Torres")).not.toBeInTheDocument();
+    expect(await screen.findByText("Rosa Vega")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Lucia Torres")).not.toBeInTheDocument();
+    });
 
-    fireEvent.click(screen.getAllByRole("button", { name: /Todos \(4\)/i })[0]);
-    fireEvent.click(screen.getByRole("button", { name: /Descansando \(1\)/i }));
+    fireEvent.click(screen.getAllByRole("button", { name: /Todos/i })[0]);
+    fireEvent.click(await screen.findByRole("button", { name: /Descansando \(1\)/i }));
 
-    expect(screen.getByText("Mario Salas")).toBeInTheDocument();
-    expect(screen.queryByText("Rosa Vega")).not.toBeInTheDocument();
+    expect(await screen.findByText("Mario Salas")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Rosa Vega")).not.toBeInTheDocument();
+    });
   });
 
   it("muestra mensaje sin resultados cuando ningun conductor coincide", async () => {
@@ -163,7 +205,7 @@ describe("HU10 - Gestion de conductores", () => {
       target: { value: "no existe" },
     });
 
-    expect(screen.getByText("No se encontraron conductores")).toBeInTheDocument();
+    expect(await screen.findByText("No se encontraron conductores")).toBeInTheDocument();
   });
 
   it("permite drill-down desde las graficas y actualiza la tabla", async () => {
@@ -172,14 +214,18 @@ describe("HU10 - Gestion de conductores", () => {
     await screen.findByText("Carlos Ramirez");
     fireEvent.click(screen.getByTestId("bar-descansando"));
 
-    expect(screen.getByText("Mario Salas")).toBeInTheDocument();
-    expect(screen.queryByText("Carlos Ramirez")).not.toBeInTheDocument();
+    expect(await screen.findByText("Mario Salas")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Carlos Ramirez")).not.toBeInTheDocument();
+    });
 
     fireEvent.click(screen.getByTestId("pie-activos"));
 
-    expect(screen.getByText("Carlos Ramirez")).toBeInTheDocument();
+    expect(await screen.findByText("Carlos Ramirez")).toBeInTheDocument();
     expect(screen.getByText("Lucia Torres")).toBeInTheDocument();
-    expect(screen.queryByText("Rosa Vega")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Rosa Vega")).not.toBeInTheDocument();
+    });
   });
 
   it("redirige a la ficha individual HU20 al hacer clic en Ver", async () => {

--- a/apps/mfe-dashboard/src/modules/gestión-conductores/pages/GestionConductoresPage.tsx
+++ b/apps/mfe-dashboard/src/modules/gestión-conductores/pages/GestionConductoresPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getDashboardConductores } from '@nanutech/api-client';
 import { MonitoreoSidebar } from '../../monitoreo-camiones/components/MonitoreoSidebar';
@@ -19,96 +19,116 @@ import type {
   EstadoFiltro,
   PanelConductores,
 } from '../types';
-import { formatFechaLarga, formatHora, normalizeText } from '../utils/format';
+import { formatFechaLarga, formatHora } from '../utils/format';
 import { normalizePanelConductores } from '../utils/normalize';
 
+// Pantalla principal de HU10: panel centralizado de gestion de conductores.
 function GestionConductoresPage() {
+  // Permite navegar hacia la ficha individual HU20 cuando se presiona "Ver".
   const navigate = useNavigate();
+  // Guarda KPIs, graficas y conductores normalizados para renderizar toda la vista.
   const [panel, setPanel] = useState<PanelConductores>(initialPanelConductores);
+  // Controla el texto de carga mientras se consulta el backend.
   const [loading, setLoading] = useState(true);
+  // Texto enviado al backend como query param busqueda.
   const [search, setSearch] = useState('');
+  // Filtro de estado contractual: TODOS, ACTIVOS o INACTIVOS.
   const [estado, setEstado] = useState<EstadoFiltro>('TODOS');
+  // Filtro operacional: DISPONIBLE, EN_RUTA, DESCANSANDO, etc.
   const [disponibilidad, setDisponibilidad] = useState<DisponibilidadFiltro>('TODOS');
+  // Fecha visible en el encabezado.
   const [fechaActual, setFechaActual] = useState('');
+  // Hora visible como "Ultima actualizacion".
   const [horaActual, setHoraActual] = useState('');
 
+  // Mantiene actualizado el reloj de cabecera cada segundo.
   useEffect(() => {
+    // Calcula fecha y hora usando formato local Peru.
     const actualizarReloj = () => {
       const ahora = new Date();
       setFechaActual(formatFechaLarga(ahora));
       setHoraActual(formatHora(ahora));
     };
 
+    // Inicializa el reloj inmediatamente para no mostrar campos vacios.
     actualizarReloj();
+    // Refresca el reloj sin volver a consultar el backend.
     const interval = window.setInterval(actualizarReloj, 1000);
+    // Limpia el intervalo cuando el componente se desmonta.
     return () => window.clearInterval(interval);
   }, []);
 
+  // Carga resumen y listado cada vez que cambian filtros o busqueda.
   useEffect(() => {
+    // Evita setState si la promesa termina despues de desmontar el componente.
     let mounted = true;
 
+    // Consulta el api-client, normaliza la respuesta y actualiza el panel.
     const cargarConductores = async () => {
+      setLoading(true);
+
       try {
-        const data = await getDashboardConductores();
+        // El backend real separa /resumen y /listado; esta funcion los une.
+        const data = await getDashboardConductores({
+          busqueda: search,
+          estado,
+          disponibilidad,
+          page: 1,
+          limit: 20,
+        });
+        // Solo actualiza estado si el componente sigue montado.
         if (mounted) setPanel(normalizePanelConductores(data));
       } catch {
+        // Si backend no responde, deja mocks para que la pantalla siga usable.
         if (mounted) setPanel(initialPanelConductores);
       } finally {
+        // Cierra el estado de carga tanto en exito como en error.
         if (mounted) setLoading(false);
       }
     };
 
+    // Carga inicial con los filtros actuales.
     cargarConductores();
+    // Refresca datos periodicamente para simular monitoreo en vivo.
     const interval = window.setInterval(cargarConductores, 30000);
 
+    // Cancela actualizaciones pendientes y el polling al cambiar filtros/desmontar.
     return () => {
       mounted = false;
       window.clearInterval(interval);
     };
-  }, []);
+  }, [disponibilidad, estado, search]);
 
-  const conductoresFiltrados = useMemo(() => {
-    const texto = normalizeText(search);
-
-    return panel.conductores.filter((conductor) => {
-      const coincideBusqueda =
-        !texto ||
-        normalizeText(conductor.nombre).includes(texto) ||
-        normalizeText(conductor.dni).includes(texto) ||
-        normalizeText(conductor.licencia).includes(texto);
-
-      const coincideEstado =
-        estado === 'TODOS' ||
-        (estado === 'ACTIVOS' && conductor.activo) ||
-        (estado === 'INACTIVOS' && !conductor.activo);
-
-      const coincideDisponibilidad =
-        disponibilidad === 'TODOS' ||
-        conductor.estadoOperacional === disponibilidad;
-
-      return coincideBusqueda && coincideEstado && coincideDisponibilidad;
-    });
-  }, [disponibilidad, estado, panel.conductores, search]);
-
+  // Drill-down desde la grafica de contratos hacia el filtro Activos/Inactivos.
   const handleContratoClick = (key: string) => {
+    // Al filtrar por contrato se limpia disponibilidad para evitar cruces confusos.
     setDisponibilidad('TODOS');
-    setEstado(key === 'ACTIVO' ? 'ACTIVOS' : 'INACTIVOS');
+    // Backend espera ACTIVO(S) como ACTIVOS; cualquier otro segmento cae en INACTIVOS.
+    setEstado(key === 'ACTIVO' || key === 'ACTIVOS' ? 'ACTIVOS' : 'INACTIVOS');
   };
 
+  // Drill-down desde la grafica operacional hacia el filtro de disponibilidad.
   const handleOperacionalClick = (key: string) => {
+    // Al filtrar por disponibilidad se limpia estado contractual.
     setEstado('TODOS');
+    // La key viene de la grafica y coincide con el enum de disponibilidad.
     setDisponibilidad(key as DisponibilidadFiltro);
   };
 
+  // Navega a la futura ficha individual del conductor HU20.
   const handleView = (conductor: ConductorDashboard) => {
     navigate(`/dashboard/admin/conductores/${conductor.id}`);
   };
 
+  // Layout completo: sidebar, cabecera, KPIs, graficas y tabla.
   return (
     <div className="flex min-h-screen bg-gray-50 font-sans">
+      {/* Sidebar reutilizado del dashboard admin para mantener navegacion consistente. */}
       <MonitoreoSidebar />
 
+      {/* Contenedor principal desplazado por el sidebar fijo. */}
       <div className="ml-52 flex min-h-screen flex-1 flex-col">
+        {/* Cabecera superior con fecha y hora de actualizacion. */}
         <header className="sticky top-0 z-10 flex items-start justify-between border-b border-gray-200 bg-white px-8 py-4">
           <div>
             <h1 className="text-lg font-bold text-gray-900">Conductores</h1>
@@ -121,6 +141,7 @@ function GestionConductoresPage() {
         </header>
 
         <main className="flex-1 px-8 py-6">
+          {/* Titulo funcional de la HU10. */}
           <section className="mb-6 flex items-start justify-between">
             <div>
               <h2 className="text-2xl font-bold text-gray-900">Gestion de Conductores</h2>
@@ -136,6 +157,7 @@ function GestionConductoresPage() {
             </div>
           </section>
 
+          {/* Tarjetas resumen alimentadas por /conductores/dashboard/resumen. */}
           <section className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
             <SummaryCard
               title="Total Conductores"
@@ -167,6 +189,7 @@ function GestionConductoresPage() {
             />
           </section>
 
+          {/* Graficas interactivas; sus clicks actualizan filtros de backend. */}
           <div className="mt-5">
             <ConductoresCharts
               contratoData={panel.graficas.contrato}
@@ -176,12 +199,14 @@ function GestionConductoresPage() {
             />
           </div>
 
+          {/* Tabla de conductores alimentada por /conductores/dashboard/listado. */}
           <section className="mt-5 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
             <div className="mb-4">
               <h3 className="text-sm font-bold text-gray-900">Listado de Conductores</h3>
               <p className="text-xs text-gray-500">Todos los conductores registrados en el sistema</p>
             </div>
 
+            {/* Controles que actualizan los query params enviados al backend. */}
             <ConductoresFilters
               conductores={panel.conductores}
               search={search}
@@ -193,10 +218,11 @@ function GestionConductoresPage() {
             />
 
             <div className="mt-4">
+              {/* Mientras llega la respuesta, se evita mostrar una tabla desactualizada. */}
               {loading ? (
                 <p className="py-8 text-center text-sm text-gray-500">Cargando conductores...</p>
               ) : (
-                <ConductoresTable conductores={conductoresFiltrados} onView={handleView} />
+                <ConductoresTable conductores={panel.conductores} onView={handleView} />
               )}
             </div>
           </section>

--- a/apps/mfe-dashboard/src/modules/gestión-conductores/utils/normalize.ts
+++ b/apps/mfe-dashboard/src/modules/gestión-conductores/utils/normalize.ts
@@ -1,5 +1,5 @@
 import type { DashboardConductoresApi } from '@nanutech/api-client';
-import type { ConductorDashboard, PanelConductores } from '../types';
+import type { ConductorDashboard, PanelConductores, SegmentoGrafica } from '../types';
 import {
   normalizeEstadoContrato,
   normalizeEstadoOperacional,
@@ -8,6 +8,7 @@ import {
 } from './format';
 import { buildPanelConductores } from './panel';
 
+// Lee el primer campo existente dentro de una lista de posibles nombres.
 const read = (source: Record<string, unknown>, keys: string[]) => {
   for (const key of keys) {
     const value = source[key];
@@ -17,17 +18,21 @@ const read = (source: Record<string, unknown>, keys: string[]) => {
   return undefined;
 };
 
+// Convierte una fila del backend al modelo que necesita la tabla HU10.
 const normalizeConductor = (
   raw: Record<string, unknown>,
   index: number,
 ): ConductorDashboard => {
+  // Normaliza estado contractual aunque venga como estadoContrato, estado_contrato o estado.
   const estadoContrato = normalizeEstadoContrato(
     read(raw, ['estadoContrato', 'estado_contrato', 'estado', 'contrato_estado']),
     read(raw, ['activo', 'is_active']),
   );
+  // Normaliza disponibilidad aunque venga en camelCase, snake_case o como estado_jornada.
   const estadoOperacional = normalizeEstadoOperacional(
     read(raw, ['estadoOperacional', 'estado_operacional', 'disponibilidad', 'estado_jornada']),
   );
+  // Obtiene placa/camion asignado desde cualquiera de los nombres usados por backend.
   const camion = read(raw, [
     'camionAsignado',
     'camion_asignado',
@@ -35,7 +40,12 @@ const normalizeConductor = (
     'placa_camion',
     'unidad_asignada',
   ]);
+  // Convierte strings vacios o valores inexistentes a null.
+  const camionAsignado = typeof camion === 'string' && camion.trim()
+    ? camion.trim()
+    : null;
 
+  // Retorna una fila completa con defaults seguros para campos que backend no envia.
   return {
     id: toStringValue(read(raw, ['id', 'conductor_id', 'uuid']), `conductor-${index + 1}`),
     nombre: toStringValue(read(raw, ['nombre', 'nombre_completo', 'name']), 'Sin nombre'),
@@ -45,32 +55,39 @@ const normalizeConductor = (
     contacto: toStringValue(read(raw, ['contacto', 'telefono', 'celular']), '-'),
     estadoContrato,
     estadoOperacional,
-    camionAsignado: typeof camion === 'string' && camion.trim() ? camion.trim() : null,
+    // Backend manda "Sin asignar"; la UI lo trata como ausencia de placa real.
+    camionAsignado: camionAsignado?.toLowerCase() === 'sin asignar' ? null : camionAsignado,
     activo: estadoContrato === 'ACTIVO',
   };
 };
 
+// Sobrescribe los KPIs calculados localmente con los indicadores oficiales del backend.
 const overrideResumen = (
   panel: PanelConductores,
   resumen?: Record<string, unknown>,
 ): PanelConductores => {
+  // Si el backend no mando resumen, se conservan los valores calculados por lista.
   if (!resumen) return panel;
 
   return {
     ...panel,
     resumen: {
+      // Total de conductores registrados.
       totalConductores: toNumber(
         read(resumen, ['totalConductores', 'total_conductores', 'total']),
         panel.resumen.totalConductores,
       ),
+      // Conductores con contrato vigente/activo.
       conductoresActivos: toNumber(
         read(resumen, ['conductoresActivos', 'conductores_activos', 'activos']),
         panel.resumen.conductoresActivos,
       ),
+      // Conductores disponibles para asignacion.
       disponibles: toNumber(
         read(resumen, ['disponibles', 'conductores_disponibles']),
         panel.resumen.disponibles,
       ),
+      // Personal actualmente en ruta.
       enRuta: toNumber(
         read(resumen, ['enRuta', 'en_ruta', 'personal_en_ruta']),
         panel.resumen.enRuta,
@@ -79,13 +96,89 @@ const overrideResumen = (
   };
 };
 
+// Asigna color de grafica a cada segmento segun su key normalizada.
+const chartColor = (key: string) => {
+  // INACTIVO debe evaluarse antes de ACTIVO porque contiene esa palabra.
+  if (key.includes('INACTIVO')) return '#ef4444';
+  if (key.includes('ACTIVO')) return '#10b981';
+  if (key.includes('SUSPEND')) return '#f97316';
+  if (key.includes('RUTA')) return '#3b82f6';
+  if (key.includes('DESCANS')) return '#f97316';
+  if (key.includes('PERMISO')) return '#94a3b8';
+  return '#22c55e';
+};
+
+// Convierte keys como EN_RUTA en etiquetas legibles como En Ruta.
+const chartLabel = (key: string) =>
+  key
+    .toLowerCase()
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+// Normaliza arrays de grafica del backend: { estado, cantidad } -> SegmentoGrafica.
+const normalizeChartList = (
+  value: unknown,
+  fallback: SegmentoGrafica[],
+): SegmentoGrafica[] => {
+  // Si backend no manda una lista valida, se mantiene la grafica calculada localmente.
+  if (!Array.isArray(value)) return fallback;
+
+  return value.map((item) => {
+    // Cada item del backend puede usar estado/key y cantidad/value/total.
+    const raw = item as Record<string, unknown>;
+    const key = toStringValue(read(raw, ['estado', 'key']), 'SIN_DATO').toUpperCase();
+
+    // Devuelve la forma que espera Recharts.
+    return {
+      key,
+      label: chartLabel(key),
+      value: toNumber(read(raw, ['cantidad', 'value', 'total']), 0),
+      color: chartColor(key),
+    };
+  });
+};
+
+// Sobrescribe graficas calculadas con graficas oficiales de /resumen.
+const overrideGraficas = (
+  panel: PanelConductores,
+  graficas?: Record<string, unknown>,
+): PanelConductores => {
+  // Si no hay graficas del backend, se conservan las generadas desde la lista.
+  if (!graficas) return panel;
+
+  return {
+    ...panel,
+    graficas: {
+      // Backend manda distribucionContrato para el pie chart.
+      contrato: normalizeChartList(
+        read(graficas, ['distribucionContrato', 'distribucion_contrato', 'contrato']),
+        panel.graficas.contrato,
+      ),
+      // Backend manda estadoOperacional para el bar chart.
+      operacional: normalizeChartList(
+        read(graficas, ['estadoOperacional', 'estado_operacional', 'operacional']),
+        panel.graficas.operacional,
+      ),
+    },
+  };
+};
+
+// Normaliza la respuesta agregada del api-client para que la UI use un solo modelo.
 export const normalizePanelConductores = (
   payload: DashboardConductoresApi,
 ): PanelConductores => {
+  // El listado puede venir como conductores o listado segun version del contrato.
   const listado = payload.conductores ?? payload.listado ?? [];
+  // Convierte cada fila cruda en ConductorDashboard.
   const conductores = listado.map((item, index) =>
     normalizeConductor(item, index),
   );
+  // Resumen puede venir como indicadores cuando se consume /resumen.
+  const resumen = payload.indicadores ?? payload.resumen;
+  // Graficas puede venir como graficos cuando se consume /resumen.
+  const graficas = payload.graficos ?? payload.graficas;
 
-  return overrideResumen(buildPanelConductores(conductores), payload.resumen);
+  // Base local + overrides oficiales del backend.
+  return overrideGraficas(overrideResumen(buildPanelConductores(conductores), resumen), graficas);
 };

--- a/apps/mfe-dashboard/src/modules/gestión-conductores/utils/panel.ts
+++ b/apps/mfe-dashboard/src/modules/gestión-conductores/utils/panel.ts
@@ -9,6 +9,7 @@ import type {
   SegmentoGrafica,
 } from '../types';
 
+// Estados que se muestran en la grafica operacional del HU10.
 const estadosOperacionales: EstadoOperacional[] = [
   'DISPONIBLE',
   'EN_RUTA',
@@ -16,12 +17,17 @@ const estadosOperacionales: EstadoOperacional[] = [
   'DE_PERMISO',
 ];
 
+// Construye un panel completo usando solo una lista de conductores.
 export const buildPanelConductores = (
   conductores: readonly ConductorDashboard[],
 ): PanelConductores => {
+  // Total de filas recibidas.
   const totalConductores = conductores.length;
+  // Conductores activos segun estado contractual normalizado.
   const conductoresActivos = conductores.filter((conductor) => conductor.activo).length;
+  // Conductores con jornada activa o camion asignado en ruta.
   const enRuta = conductores.filter((conductor) => conductor.estadoOperacional === 'EN_RUTA').length;
+  // Regla HU10: disponible = contrato activo + sin jornada en ruta + estado DISPONIBLE.
   const disponibles = conductores.filter(
     (conductor) =>
       conductor.estadoContrato === 'ACTIVO' &&
@@ -29,16 +35,19 @@ export const buildPanelConductores = (
       conductor.estadoOperacional === 'DISPONIBLE',
   ).length;
 
+  // Segmentos para grafica de estado de contrato.
   const activos = conductores.filter((conductor) => conductor.estadoContrato === 'ACTIVO').length;
   const inactivos = conductores.filter((conductor) => conductor.estadoContrato === 'INACTIVO').length;
   const suspendidos = conductores.filter((conductor) => conductor.estadoContrato === 'SUSPENDIDO').length;
 
+  // Pie chart de distribucion contractual.
   const contrato: SegmentoGrafica[] = [
     { key: 'ACTIVO', label: 'Activos', value: activos, color: '#10b981' },
     { key: 'INACTIVO', label: 'Inactivos', value: inactivos, color: '#ef4444' },
     { key: 'SUSPENDIDO', label: 'Suspendidos', value: suspendidos, color: '#f97316' },
   ];
 
+  // Bar chart de estado operacional.
   const operacional: SegmentoGrafica[] = estadosOperacionales.map((estado) => ({
     key: estado,
     label: ESTADO_OPERACIONAL_LABEL[estado],
@@ -46,6 +55,7 @@ export const buildPanelConductores = (
     color: ESTADO_OPERACIONAL_COLOR[estado],
   }));
 
+  // Devuelve el objeto unico que consume la pagina.
   return {
     resumen: {
       totalConductores,

--- a/packages/api-client/src/services/conductores/conductoresDashboard.ts
+++ b/packages/api-client/src/services/conductores/conductoresDashboard.ts
@@ -1,7 +1,9 @@
 import apiClient from '../../../index';
 
+// Estados aceptados por el backend para filtrar el listado por contrato.
 export type EstadoFiltroConductores = 'TODOS' | 'ACTIVOS' | 'INACTIVOS';
 
+// Estados operacionales aceptados por el backend para filtrar disponibilidad.
 export type DisponibilidadFiltroConductores =
   | 'TODOS'
   | 'DISPONIBLE'
@@ -10,41 +12,100 @@ export type DisponibilidadFiltroConductores =
   | 'DE_PERMISO'
   | 'SIN_ASIGNAR';
 
+// Parametros que la pantalla HU10 envia a /conductores/dashboard/listado.
 export type FiltrosDashboardConductores = {
   busqueda?: string;
   estado?: EstadoFiltroConductores;
   disponibilidad?: DisponibilidadFiltroConductores;
+  page?: number;
+  limit?: number;
 };
 
+// Tipo flexible porque el backend puede agregar campos sin romper el frontend.
 export type ConductorDashboardApi = Record<string, unknown>;
 
-export type DashboardConductoresApi = {
-  resumen?: Record<string, unknown>;
-  graficas?: Record<string, unknown>;
-  conductores?: ConductorDashboardApi[];
-  listado?: ConductorDashboardApi[];
+// Respuesta de /conductores/dashboard/resumen: KPIs y datos de graficas.
+export type ResumenDashboardConductoresApi = {
+  indicadores?: Record<string, unknown>;
+  graficos?: Record<string, unknown>;
 };
 
+// Respuesta de /conductores/dashboard/listado: filas de tabla y paginacion.
+export type ListadoDashboardConductoresApi = {
+  conductores?: ConductorDashboardApi[];
+  paginacion?: Record<string, unknown>;
+  mensajeSinResultados?: string | null;
+};
+
+// Modelo agregado que consume la pantalla para no depender de dos llamadas separadas.
+export type DashboardConductoresApi = {
+  resumen?: Record<string, unknown>;
+  indicadores?: Record<string, unknown>;
+  graficas?: Record<string, unknown>;
+  graficos?: Record<string, unknown>;
+  conductores?: ConductorDashboardApi[];
+  listado?: ConductorDashboardApi[];
+  paginacion?: Record<string, unknown>;
+  mensajeSinResultados?: string | null;
+};
+
+// Estructura comun que usa el backend: { success, message, data }.
 type ApiResponse<T> = {
   success?: boolean;
   message?: string;
   data?: T;
 } & T;
 
-export const getDashboardConductores = async (
-  filters: FiltrosDashboardConductores = {},
-): Promise<DashboardConductoresApi> => {
-  const params = {
-    ...filters,
-    estado: filters.estado === 'TODOS' ? undefined : filters.estado,
-    disponibilidad:
-      filters.disponibilidad === 'TODOS' ? undefined : filters.disponibilidad,
+// Limpia filtros antes de enviarlos: no manda TODOS ni busquedas vacias.
+const cleanFilters = (filters: FiltrosDashboardConductores = {}) => ({
+  busqueda: filters.busqueda?.trim() || undefined,
+  estado: filters.estado === 'TODOS' ? undefined : filters.estado,
+  disponibilidad:
+    filters.disponibilidad === 'TODOS' ? undefined : filters.disponibilidad,
+  page: filters.page ?? 1,
+  limit: filters.limit ?? 20,
+});
+
+// Obtiene indicadores y graficas desde el endpoint real de resumen.
+export const getResumenDashboardConductores =
+  async (): Promise<ResumenDashboardConductoresApi> => {
+    const response = await apiClient.get<ApiResponse<ResumenDashboardConductoresApi>>(
+      '/conductores/dashboard/resumen',
+    );
+
+    return response.data.data ?? response.data;
   };
 
-  const response = await apiClient.get<ApiResponse<DashboardConductoresApi>>(
-    '/conductores/dashboard',
-    { params },
+// Obtiene el listado paginado y filtrado desde el endpoint real de tabla.
+export const getListadoDashboardConductores = async (
+  filters: FiltrosDashboardConductores = {},
+): Promise<ListadoDashboardConductoresApi> => {
+  const response = await apiClient.get<ApiResponse<ListadoDashboardConductoresApi>>(
+    '/conductores/dashboard/listado',
+    { params: cleanFilters(filters) },
   );
 
   return response.data.data ?? response.data;
+};
+
+// Une resumen + listado en una sola funcion para simplificar la pagina HU10.
+export const getDashboardConductores = async (
+  filters: FiltrosDashboardConductores = {},
+): Promise<DashboardConductoresApi> => {
+  // Ejecuta ambas llamadas en paralelo porque resumen y listado son independientes.
+  const [resumen, listado] = await Promise.all([
+    getResumenDashboardConductores(),
+    getListadoDashboardConductores(filters),
+  ]);
+
+  // Devuelve aliases camel-ish y legacy para que el normalizador soporte ambos contratos.
+  return {
+    resumen: resumen.indicadores,
+    indicadores: resumen.indicadores,
+    graficas: resumen.graficos,
+    graficos: resumen.graficos,
+    conductores: listado.conductores ?? [],
+    paginacion: listado.paginacion,
+    mensajeSinResultados: listado.mensajeSinResultados ?? null,
+  };
 };


### PR DESCRIPTION
#57 

## Descripción

Se corrige y ajusta la HU10: Panel de Gestión de Conductores, alineando el consumo del frontend con los endpoints reales entregados por backend.

## Cambios realizados

- Se actualizó el consumo de datos de HU10 para usar los endpoints reales:
  - `GET /conductores/dashboard/resumen`
  - `GET /conductores/dashboard/listado`
- Se separó el consumo de:
  - Indicadores y gráficas desde `/resumen`
  - Tabla de conductores desde `/listado`
- Se agregaron filtros enviados al backend:
  - `busqueda`
  - `estado`
  - `disponibilidad`
  - `page`
  - `limit`
- Se ajustó la normalización de datos para soportar el contrato real del backend:
  - `indicadores`
  - `graficos`
  - `distribucionContrato`
  - `estadoOperacional`
  - `conductores`
  - `paginacion`
  - `mensajeSinResultados`
- Se corrigió el tratamiento de `camionAsignado: "Sin asignar"` para mostrarlo como conductor sin unidad asignada.
- Se corrigió el color de segmentos `INACTIVOS` en la gráfica de contratos.
- Se agregaron comentarios explicativos en los archivos principales de HU10.
- Se actualizaron pruebas unitarias de HU10 según el nuevo contrato del backend.

## Pruebas

Se validó con:

```bash
npm run test -w apps/mfe-dashboard -- hu10-gestión-conductores
npm run type-check
npm run build -w apps/mfe-dashboard


