### PR TITLE
fix: HU10 - Panel de Gestión de Conductores

### DIFF
--- a/apps/mfe-dashboard/__tests__/unit/hu10-gestión-conductores/GestionConductoresPage.test.tsx
+++ b/apps/mfe-dashboard/__tests__/unit/hu10-gestión-conductores/GestionConductoresPage.test.tsx
@@ -13,6 +13,13 @@ vi.mock("recharts", () => ({
       <button type="button" data-testid="pie-activos" onClick={() => onClick?.({ key: "ACTIVO" })}>
         segmento-activos
       </button>
+      <button
+        type="button"
+        data-testid="pie-activos-payload"
+        onClick={() => onClick?.({ payload: { key: "ACTIVOS" } })}
+      >
+        segmento-activos-payload
+      </button>
       {children}
     </div>
   ),
@@ -208,6 +215,37 @@ describe("HU10 - Gestion de conductores", () => {
     expect(await screen.findByText("No se encontraron conductores")).toBeInTheDocument();
   });
 
+  it("muestra un error visible cuando la API no responde", async () => {
+    vi.mocked(getDashboardConductores).mockRejectedValueOnce(new Error("Network Error"));
+
+    renderPage();
+
+    expect(await screen.findByText("No se pudo conectar con el backend")).toBeInTheDocument();
+    expect(screen.getByText(/VITE_API_URL/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Reintentar/i })).toBeInTheDocument();
+  });
+
+  it("advierte cuando el backend responde sin conductores", async () => {
+    vi.mocked(getDashboardConductores).mockResolvedValueOnce({
+      indicadores: {
+        total_conductores: 0,
+        conductores_activos: 0,
+        disponibles: 0,
+        en_ruta: 0,
+      },
+      graficos: {
+        distribucionContrato: [],
+        estadoOperacional: [],
+      },
+      conductores: [],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("El backend respondio sin conductores registrados")).toBeInTheDocument();
+    expect(screen.getByText(/usuarios con rol CHOFER/i)).toBeInTheDocument();
+  });
+
   it("permite drill-down desde las graficas y actualiza la tabla", async () => {
     renderPage();
 
@@ -220,6 +258,19 @@ describe("HU10 - Gestion de conductores", () => {
     });
 
     fireEvent.click(screen.getByTestId("pie-activos"));
+
+    expect(await screen.findByText("Carlos Ramirez")).toBeInTheDocument();
+    expect(screen.getByText("Lucia Torres")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Rosa Vega")).not.toBeInTheDocument();
+    });
+  });
+
+  it("filtra la tabla cuando Recharts envia la key del PieChart dentro de payload", async () => {
+    renderPage();
+
+    await screen.findByText("Rosa Vega");
+    fireEvent.click(screen.getByTestId("pie-activos-payload"));
 
     expect(await screen.findByText("Carlos Ramirez")).toBeInTheDocument();
     expect(screen.getByText("Lucia Torres")).toBeInTheDocument();

--- a/apps/mfe-dashboard/src/modules/gestión-conductores/components/ConductoresCharts.tsx
+++ b/apps/mfe-dashboard/src/modules/gestión-conductores/components/ConductoresCharts.tsx
@@ -19,10 +19,21 @@ type ConductoresChartsProps = {
   onOperacionalClick: (key: string) => void;
 };
 
-const getSegmentKey = (entry: unknown) =>
-  typeof entry === 'object' && entry !== null && 'key' in entry
-    ? String((entry as { key: unknown }).key)
-    : '';
+const getSegmentKey = (entry: unknown) => {
+  if (typeof entry !== 'object' || entry === null) return '';
+
+  const segment = entry as {
+    key?: unknown;
+    payload?: {
+      key?: unknown;
+    };
+  };
+
+  if (segment.key) return String(segment.key);
+  if (segment.payload?.key) return String(segment.payload.key);
+
+  return '';
+};
 
 const getActivePayloadKey = (state: unknown) => {
   const activePayload = (state as { activePayload?: Array<{ payload?: { key?: unknown } }> })

--- a/apps/mfe-dashboard/src/modules/gestión-conductores/components/ConductoresTable.tsx
+++ b/apps/mfe-dashboard/src/modules/gestión-conductores/components/ConductoresTable.tsx
@@ -57,7 +57,9 @@ export function ConductoresTable({ conductores, onView }: ConductoresTableProps)
                     </div>
                     <div>
                       <p className="font-bold text-gray-900">{conductor.nombre}</p>
-                      <p className="text-[11px] text-gray-500">{conductor.email}</p>
+                      {conductor.email && (
+                        <p className="text-[11px] text-gray-500">{conductor.email}</p>
+                      )}
                     </div>
                   </div>
                 </td>

--- a/apps/mfe-dashboard/src/modules/gestión-conductores/pages/GestionConductoresPage.tsx
+++ b/apps/mfe-dashboard/src/modules/gestión-conductores/pages/GestionConductoresPage.tsx
@@ -12,7 +12,6 @@ import {
 import { ConductoresFilters } from '../components/ConductoresFilters';
 import { ConductoresTable } from '../components/ConductoresTable';
 import { SummaryCard } from '../components/SummaryCard';
-import { initialPanelConductores } from '../mocks/conductoresMock';
 import type {
   ConductorDashboard,
   DisponibilidadFiltro,
@@ -21,15 +20,75 @@ import type {
 } from '../types';
 import { formatFechaLarga, formatHora } from '../utils/format';
 import { normalizePanelConductores } from '../utils/normalize';
+import { buildPanelConductores } from '../utils/panel';
+
+type DashboardError = {
+  title: string;
+  message: string;
+  detail?: string;
+};
+
+// Estado vacio usado cuando el backend falla o responde sin registros.
+const emptyPanelConductores = buildPanelConductores([]);
+
+// Extrae datos utiles de errores HTTP de Axios sin acoplar el componente a Axios.
+const readHttpError = (error: unknown) => {
+  const candidate = error as {
+    message?: string;
+    response?: {
+      status?: number;
+      data?: {
+        message?: string;
+      };
+    };
+  };
+
+  return {
+    status: candidate.response?.status,
+    apiMessage: candidate.response?.data?.message,
+    message: candidate.message,
+  };
+};
+
+// Convierte errores tecnicos en mensajes visibles para QA y administradores.
+const buildDashboardError = (error: unknown): DashboardError => {
+  const { status, apiMessage, message } = readHttpError(error);
+
+  if (status === 401 || status === 403) {
+    return {
+      title: 'No se pudo cargar el panel de conductores',
+      message: 'La sesion no tiene permisos para consultar la HU10. Inicia sesion con un usuario administrador.',
+      detail: apiMessage ?? `HTTP ${status}`,
+    };
+  }
+
+  if (status) {
+    return {
+      title: 'El backend respondio con error',
+      message: 'La API de conductores no pudo entregar los indicadores o el listado.',
+      detail: apiMessage ?? `HTTP ${status}`,
+    };
+  }
+
+  return {
+    title: 'No se pudo conectar con el backend',
+    message: 'Verifica que SAM/local API este levantado y que VITE_API_URL apunte al puerto correcto.',
+    detail: message,
+  };
+};
 
 // Pantalla principal de HU10: panel centralizado de gestion de conductores.
 function GestionConductoresPage() {
   // Permite navegar hacia la ficha individual HU20 cuando se presiona "Ver".
   const navigate = useNavigate();
   // Guarda KPIs, graficas y conductores normalizados para renderizar toda la vista.
-  const [panel, setPanel] = useState<PanelConductores>(initialPanelConductores);
+  const [panel, setPanel] = useState<PanelConductores>(emptyPanelConductores);
   // Controla el texto de carga mientras se consulta el backend.
   const [loading, setLoading] = useState(true);
+  // Mensaje visible cuando la API falla, no autoriza o no esta disponible.
+  const [error, setError] = useState<DashboardError | null>(null);
+  // Permite reintentar manualmente la consulta sin cambiar filtros.
+  const [reloadKey, setReloadKey] = useState(0);
   // Texto enviado al backend como query param busqueda.
   const [search, setSearch] = useState('');
   // Filtro de estado contractual: TODOS, ACTIVOS o INACTIVOS.
@@ -66,6 +125,7 @@ function GestionConductoresPage() {
     // Consulta el api-client, normaliza la respuesta y actualiza el panel.
     const cargarConductores = async () => {
       setLoading(true);
+      setError(null);
 
       try {
         // El backend real separa /resumen y /listado; esta funcion los une.
@@ -78,9 +138,12 @@ function GestionConductoresPage() {
         });
         // Solo actualiza estado si el componente sigue montado.
         if (mounted) setPanel(normalizePanelConductores(data));
-      } catch {
-        // Si backend no responde, deja mocks para que la pantalla siga usable.
-        if (mounted) setPanel(initialPanelConductores);
+      } catch (requestError) {
+        // Si backend no responde, muestra un error visible en vez de ocultarlo con datos mock.
+        if (mounted) {
+          setPanel(emptyPanelConductores);
+          setError(buildDashboardError(requestError));
+        }
       } finally {
         // Cierra el estado de carga tanto en exito como en error.
         if (mounted) setLoading(false);
@@ -97,7 +160,7 @@ function GestionConductoresPage() {
       mounted = false;
       window.clearInterval(interval);
     };
-  }, [disponibilidad, estado, search]);
+  }, [disponibilidad, estado, reloadKey, search]);
 
   // Drill-down desde la grafica de contratos hacia el filtro Activos/Inactivos.
   const handleContratoClick = (key: string) => {
@@ -119,6 +182,16 @@ function GestionConductoresPage() {
   const handleView = (conductor: ConductorDashboard) => {
     navigate(`/dashboard/admin/conductores/${conductor.id}`);
   };
+
+  // Advierte cuando la API respondio correctamente pero no entrego ningun conductor.
+  const showEmptyBackendNotice =
+    !loading &&
+    !error &&
+    panel.resumen.totalConductores === 0 &&
+    panel.conductores.length === 0 &&
+    search.trim() === '' &&
+    estado === 'TODOS' &&
+    disponibilidad === 'TODOS';
 
   // Layout completo: sidebar, cabecera, KPIs, graficas y tabla.
   return (
@@ -156,6 +229,36 @@ function GestionConductoresPage() {
               </p>
             </div>
           </section>
+
+          {error && (
+            <section className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="font-bold">{error.title}</p>
+                  <p className="mt-1">{error.message}</p>
+                  {error.detail && (
+                    <p className="mt-1 text-xs font-medium text-red-700">Detalle: {error.detail}</p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setReloadKey((current) => current + 1)}
+                  className="rounded-md border border-red-200 bg-white px-3 py-1.5 text-xs font-bold text-red-700 transition hover:bg-red-100"
+                >
+                  Reintentar
+                </button>
+              </div>
+            </section>
+          )}
+
+          {showEmptyBackendNotice && (
+            <section className="mb-5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              <p className="font-bold">El backend respondio sin conductores registrados</p>
+              <p className="mt-1">
+                Revisa que la base conectada tenga usuarios con rol CHOFER y registros en la tabla conductores.
+              </p>
+            </section>
+          )}
 
           {/* Tarjetas resumen alimentadas por /conductores/dashboard/resumen. */}
           <section className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">

--- a/apps/mfe-dashboard/src/modules/gestión-conductores/utils/normalize.ts
+++ b/apps/mfe-dashboard/src/modules/gestión-conductores/utils/normalize.ts
@@ -49,7 +49,7 @@ const normalizeConductor = (
   return {
     id: toStringValue(read(raw, ['id', 'conductor_id', 'uuid']), `conductor-${index + 1}`),
     nombre: toStringValue(read(raw, ['nombre', 'nombre_completo', 'name']), 'Sin nombre'),
-    email: toStringValue(read(raw, ['email', 'correo']), 'sin-correo@nanutech.com'),
+    email: toStringValue(read(raw, ['email', 'correo']), ''),
     dni: toStringValue(read(raw, ['dni', 'documento', 'numero_documento']), '-'),
     licencia: toStringValue(read(raw, ['licencia', 'numero_licencia']), '-'),
     contacto: toStringValue(read(raw, ['contacto', 'telefono', 'celular']), '-'),
@@ -116,6 +116,13 @@ const chartLabel = (key: string) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
 
+// Alinea estados crudos del backend con los estados visuales de la HU10.
+const normalizeChartKey = (value: unknown) => {
+  const key = toStringValue(value, 'SIN_DATO').toUpperCase();
+  if (key === 'DESCANSO') return 'DESCANSANDO';
+  return key;
+};
+
 // Normaliza arrays de grafica del backend: { estado, cantidad } -> SegmentoGrafica.
 const normalizeChartList = (
   value: unknown,
@@ -127,7 +134,7 @@ const normalizeChartList = (
   return value.map((item) => {
     // Cada item del backend puede usar estado/key y cantidad/value/total.
     const raw = item as Record<string, unknown>;
-    const key = toStringValue(read(raw, ['estado', 'key']), 'SIN_DATO').toUpperCase();
+    const key = normalizeChartKey(read(raw, ['estado', 'key']));
 
     // Devuelve la forma que espera Recharts.
     return {

--- a/packages/api-client/src/services/conductores/conductoresDashboard.ts
+++ b/packages/api-client/src/services/conductores/conductoresDashboard.ts
@@ -56,12 +56,20 @@ type ApiResponse<T> = {
   data?: T;
 } & T;
 
+// Traduce el nombre visual de la UI al valor crudo que filtra el repository.
+const mapDisponibilidadToBackend = (
+  disponibilidad?: DisponibilidadFiltroConductores,
+) => {
+  if (!disponibilidad || disponibilidad === 'TODOS') return undefined;
+  if (disponibilidad === 'DESCANSANDO') return 'DESCANSO';
+  return disponibilidad;
+};
+
 // Limpia filtros antes de enviarlos: no manda TODOS ni busquedas vacias.
 const cleanFilters = (filters: FiltrosDashboardConductores = {}) => ({
   busqueda: filters.busqueda?.trim() || undefined,
   estado: filters.estado === 'TODOS' ? undefined : filters.estado,
-  disponibilidad:
-    filters.disponibilidad === 'TODOS' ? undefined : filters.disponibilidad,
+  disponibilidad: mapDisponibilidadToBackend(filters.disponibilidad),
   page: filters.page ?? 1,
   limit: filters.limit ?? 20,
 });


### PR DESCRIPTION
## Descripción

Se corrige y fortalece la HU10 - Panel de Gestión de Conductores para consumir correctamente los endpoints reales del backend y mejorar la trazabilidad de errores reportados por QA.

## Cambios realizados

- Se ajustó el consumo de `/conductores/dashboard/resumen` y `/conductores/dashboard/listado`.
- Se normalizó la respuesta real del backend para indicadores, gráficas y listado de conductores.
- Se corrigió el filtrado interactivo desde el PieChart y BarChart.
- Se agregó soporte para segmentos de Recharts cuando la key llega dentro de `payload`.
- Se añadieron mensajes visibles cuando falla la API, falta autorización o el backend responde sin conductores.
- Se evitó ocultar errores usando datos mock.
- Se actualizaron pruebas unitarias de HU10.

## Validación

- Se validó que el frontend mapea correctamente:
  - `total_conductores`
  - `conductores_activos`
  - `disponibles`
  - `en_ruta`
  - `distribucionContrato`
  - `estadoOperacional`
- Pruebas unitarias ejecutadas correctamente:

```bash
npm run test -w apps/mfe-dashboard -- --run "__tests__/unit/hu10-gestión-conductores/GestionConductoresPage.test.tsx"