### PR TITLE
fix: normaliza listado de jornadas en frontend

### DIFF
--- a/apps/mfe-dashboard/src/modules/registro-jornada/pages/RegistroNuevaJornada.tsx
+++ b/apps/mfe-dashboard/src/modules/registro-jornada/pages/RegistroNuevaJornada.tsx
@@ -19,6 +19,14 @@ type Jornada = {
   observaciones?: string;
 };
 
+const ACTIVE_JOURNEY_STATES = new Set(["ACTIVA", "REGISTRADA", "PENDIENTE", "EN_PROCESO"]);
+
+const normalizeJourneyState = (estado?: string) => (estado || "").toUpperCase();
+
+const isActiveJourney = (estado?: string) => ACTIVE_JOURNEY_STATES.has(normalizeJourneyState(estado));
+
+const isCompletedJourney = (estado?: string) => normalizeJourneyState(estado) === "COMPLETADA";
+
 function RegistroNuevaJornada() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -74,14 +82,15 @@ function RegistroNuevaJornada() {
 }, []);
 
   const total = jornadas.length;
-  const activas = jornadas.filter((j) => (j.estado || "").toLowerCase() === "activa").length;
-  const completadas = jornadas.filter((j) => (j.estado || "").toLowerCase() === "completada").length;
+  const activas = jornadas.filter((j) => isActiveJourney(j.estado)).length;
+  const completadas = jornadas.filter((j) => isCompletedJourney(j.estado)).length;
   const totalKm = jornadas.reduce((acc, j) => acc + Number(j.km || 0), 0);
 
   const jornadasFiltradas = jornadas.filter((j) => {
     const estadoOk =
       filtroEstado === "todas" ||
-      (j.estado || "").toLowerCase() === filtroEstado;
+      (filtroEstado === "activa" && isActiveJourney(j.estado)) ||
+      (filtroEstado === "completada" && isCompletedJourney(j.estado));
 
     const obsOk =
       filtroObs === "todas" ||
@@ -421,7 +430,7 @@ function RegistroNuevaJornada() {
                       <td className="py-3 pr-4">
                         <span
                           className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${
-                            (j.estado || "").toLowerCase() === "activa"
+                            isActiveJourney(j.estado)
                               ? "bg-blue-100 text-blue-700"
                               : "bg-green-100 text-green-700"
                           }`}

--- a/packages/api-client/src/services/registrojornada/jornadas.ts
+++ b/packages/api-client/src/services/registrojornada/jornadas.ts
@@ -9,6 +9,7 @@ export type Jornada = {
   contrato: string;
   horario: string;
   km: number | string;
+  km_recorridos?: number | string;
   estado: string;
   observaciones?: string | null;
 };
@@ -38,7 +39,10 @@ type ApiResponse<T> = {
 export const getJornadas = async (): Promise<Jornada[]> => {
   try {
     const response = await apiClient.get<ApiResponse<Jornada[]>>('/jornadas');
-    return response.data?.data || [];
+    return (response.data?.data || []).map((jornada) => ({
+      ...jornada,
+      km: jornada.km ?? jornada.km_recorridos ?? 0,
+    }));
   } catch (error) {
     console.warn('⚠️ Error obteniendo jornadas del backend:', error);
     throw new Error('Error al obtener jornadas');


### PR DESCRIPTION
## Descripción

Se ajusta el frontend de registro de jornadas para interpretar correctamente la respuesta real de `GET /jornadas`.

## Cambios

- Se normaliza `km_recorridos` como `km` en el api-client.
- Se actualiza la vista de registro de jornadas para reconocer estados reales del backend:
  - `ACTIVA`
  - `REGISTRADA`
  - `PENDIENTE`
  - `EN_PROCESO`
  - `COMPLETADA`
- Se corrige el conteo de jornadas activas y completadas.
- Se corrige el filtro por estado en la tabla.

## Validación

Se ejecutó la prueba del módulo de registro de jornada:

```bash
npm run test -w apps/mfe-dashboard -- --run "__tests__/unit/hu02-registro-jornada/RegistroJornada.test.tsx"